### PR TITLE
feat: add Miami Vice theme

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -11,6 +11,12 @@ from suppliers_db import SuppliersDB, SUPPLIERS_DB_FILE
 from bom import read_csv_flex, load_bom
 from orders import copy_per_production_and_orders, DEFAULT_FOOTER_NOTE
 
+# Miami Vice theme colors
+MIAMI_BG = "#1B1F3B"
+MIAMI_PINK = "#FF6EC7"
+MIAMI_TEAL = "#2EF9FF"
+MIAMI_TEXT = "#FFFFFF"
+
 def start_gui():
     import tkinter as tk
     from tkinter import ttk, filedialog, messagebox, simpledialog
@@ -25,30 +31,40 @@ def start_gui():
     else:
         style.theme_use("clam")
 
+    # Global styling for Miami Vice theme
+    style.configure("TFrame", background=MIAMI_BG)
+    style.configure("TLabel", background=MIAMI_BG, foreground=MIAMI_TEXT)
+    style.configure("TCheckbutton", background=MIAMI_BG, foreground=MIAMI_TEXT)
+    style.configure("TLabelframe", background=MIAMI_BG, foreground=MIAMI_TEXT)
+    style.configure("TLabelframe.Label", background=MIAMI_BG, foreground=MIAMI_TEXT)
+    style.configure("Miami.TButton", background=MIAMI_PINK, foreground=MIAMI_TEXT)
+    style.map("Miami.TButton", background=[("active", MIAMI_TEAL), ("pressed", MIAMI_TEAL)])
+
     class SuppliersManagerWin(tk.Toplevel):
         def __init__(self, master, db: SuppliersDB, on_change=None):
             super().__init__(master)
+            self.configure(bg=MIAMI_BG)
             self.title("Leveranciers Beheer")
             self.db = db
             self.on_change = on_change
             self.minsize(960, 480)
 
             # Bovenbalk: Zoek links, knoppen rechts
-            topbar = tk.Frame(self); topbar.pack(fill="x", padx=8, pady=(8,4))
-            left = tk.Frame(topbar); left.pack(side="left", fill="x", expand=True)
-            tk.Label(left, text="Zoek:").pack(side="left")
+            topbar = ttk.Frame(self); topbar.pack(fill="x", padx=8, pady=(8,4))
+            left = ttk.Frame(topbar); left.pack(side="left", fill="x", expand=True)
+            ttk.Label(left, text="Zoek:").pack(side="left")
             self.search_var = tk.StringVar()
             se = tk.Entry(left, textvariable=self.search_var, width=32)
             se.pack(side="left", padx=6)
             se.bind("<KeyRelease>", lambda e: self.refresh())
 
-            btns = tk.Frame(topbar); btns.pack(side="right")
-            tk.Button(btns, text="Toevoegen", command=self.add_supplier).pack(side="left", padx=4)
-            tk.Button(btns, text="Verwijderen", command=self.remove_sel).pack(side="left", padx=4)
-            tk.Button(btns, text="Favoriet ★", command=self.toggle_fav_sel).pack(side="left", padx=4)
-            tk.Button(btns, text="Update uit CSV (merge)", command=self.update_from_csv).pack(side="left", padx=4)
-            tk.Button(btns, text="Alles verwijderen", command=self.clear_all).pack(side="left", padx=4)
-            tk.Button(btns, text="Sluiten", command=self.destroy).pack(side="left", padx=4)
+            btns = ttk.Frame(topbar); btns.pack(side="right")
+            ttk.Button(btns, text="Toevoegen", command=self.add_supplier, style="Miami.TButton").pack(side="left", padx=4)
+            ttk.Button(btns, text="Verwijderen", command=self.remove_sel, style="Miami.TButton").pack(side="left", padx=4)
+            ttk.Button(btns, text="Favoriet ★", command=self.toggle_fav_sel, style="Miami.TButton").pack(side="left", padx=4)
+            ttk.Button(btns, text="Update uit CSV (merge)", command=self.update_from_csv, style="Miami.TButton").pack(side="left", padx=4)
+            ttk.Button(btns, text="Alles verwijderen", command=self.clear_all, style="Miami.TButton").pack(side="left", padx=4)
+            ttk.Button(btns, text="Sluiten", command=self.destroy, style="Miami.TButton").pack(side="left", padx=4)
 
             # Tabel: verberg postcode, gemeente, land
             cols = ("★","Supplier","Description","BTW","E-mail","Tel","Adres_1","Adres_2")
@@ -151,6 +167,7 @@ def start_gui():
         """
         def __init__(self, master, productions: List[str], db: SuppliersDB, callback):
             super().__init__(master)
+            self.configure(bg=MIAMI_BG)
             self.title("Selecteer leveranciers per productie")
             self.db = db
             self.callback = callback
@@ -162,19 +179,19 @@ def start_gui():
             self.grid_columnconfigure(0, weight=1)
             self.grid_rowconfigure(0, weight=1)
 
-            content = tk.Frame(self)
+            content = ttk.Frame(self)
             content.grid(row=0, column=0, sticky="nsew", padx=10, pady=6)
             content.grid_columnconfigure(0, weight=1)  # left
             content.grid_columnconfigure(1, weight=0)  # right
 
             # Left: per productie comboboxen
-            left = tk.Frame(content)
+            left = ttk.Frame(content)
             left.grid(row=0, column=0, sticky="nw", padx=(0,8))
             self.rows = []
             for prod in productions:
-                row = tk.Frame(left)
+                row = ttk.Frame(left)
                 row.pack(fill="x", pady=3)
-                tk.Label(row, text=prod, width=18, anchor="w").pack(side="left")
+                ttk.Label(row, text=prod, width=18, anchor="w").pack(side="left")
                 var = tk.StringVar()
                 self.sel_vars[prod] = var
                 combo = ttk.Combobox(row, textvariable=var, state="normal", width=50)
@@ -185,23 +202,23 @@ def start_gui():
                 self.rows.append((prod, combo))
 
             # Right: preview details (klikbaar) in LabelFrame met ondertitel
-            right = tk.LabelFrame(content,
+            right = ttk.LabelFrame(content,
                                   text="Leverancier details\n(klik om te selecteren)",
                                   labelanchor="n")
             right.grid(row=0, column=1, sticky="ne", padx=(8,0))
-            self.preview = tk.Label(right, text="", justify="left", anchor="nw", cursor="hand2")
+            self.preview = ttk.Label(right, text="", justify="left", anchor="nw", cursor="hand2")
             self.preview.pack(fill="both", expand=True, padx=8, pady=8)
             self.preview.configure(wraplength=360)
             self.preview.bind("<Button-1>", self._on_preview_click)
 
             # Buttons bar (altijd zichtbaar)
-            btns = tk.Frame(self)
+            btns = ttk.Frame(self)
             btns.grid(row=1, column=0, sticky="ew", padx=10, pady=(6,10))
             btns.grid_columnconfigure(0, weight=1)
             self.remember_var = tk.BooleanVar(value=True)
-            tk.Checkbutton(btns, text="Onthoud keuze per productie", variable=self.remember_var).grid(row=0, column=0, sticky="w")
-            tk.Button(btns, text="Annuleer", command=self.destroy).grid(row=0, column=1, sticky="e", padx=(4,0))
-            tk.Button(btns, text="Bevestig", command=self._confirm).grid(row=0, column=2, sticky="e")
+            ttk.Checkbutton(btns, text="Onthoud keuze per productie", variable=self.remember_var).grid(row=0, column=0, sticky="w")
+            ttk.Button(btns, text="Annuleer", command=self.destroy, style="Miami.TButton").grid(row=0, column=1, sticky="e", padx=(4,0))
+            ttk.Button(btns, text="Bevestig", command=self._confirm, style="Miami.TButton").grid(row=0, column=2, sticky="e")
 
             # Init
             self._refresh_options(initial=True)
@@ -340,6 +357,7 @@ def start_gui():
     class App(tk.Tk):
         def __init__(self):
             super().__init__()
+            self.configure(bg=MIAMI_BG)
             self.title("File Hopper – Miami Vice Edition (Dual-mode)")
             self.minsize(1024, 720)
 
@@ -350,28 +368,28 @@ def start_gui():
             self.bom_df: Optional[pd.DataFrame] = None
 
             # Top folders
-            top = tk.Frame(self); top.pack(fill="x", padx=8, pady=6)
-            tk.Label(top, text="Bronmap:").grid(row=0, column=0, sticky="w")
+            top = ttk.Frame(self); top.pack(fill="x", padx=8, pady=6)
+            ttk.Label(top, text="Bronmap:").grid(row=0, column=0, sticky="w")
             self.src_entry = tk.Entry(top, width=60); self.src_entry.grid(row=0, column=1, padx=4)
-            tk.Button(top, text="Bladeren", command=self._pick_src).grid(row=0, column=2, padx=4)
+            ttk.Button(top, text="Bladeren", command=self._pick_src, style="Miami.TButton").grid(row=0, column=2, padx=4)
 
-            tk.Label(top, text="Bestemmingsmap:").grid(row=1, column=0, sticky="w")
+            ttk.Label(top, text="Bestemmingsmap:").grid(row=1, column=0, sticky="w")
             self.dst_entry = tk.Entry(top, width=60); self.dst_entry.grid(row=1, column=1, padx=4)
-            tk.Button(top, text="Bladeren", command=self._pick_dst).grid(row=1, column=2, padx=4)
+            ttk.Button(top, text="Bladeren", command=self._pick_dst, style="Miami.TButton").grid(row=1, column=2, padx=4)
 
             # Filters
-            filt = tk.LabelFrame(self, text="Selecteer bestandstypen om te kopiëren", labelanchor="n"); filt.pack(fill="x", padx=8, pady=6)
+            filt = ttk.LabelFrame(self, text="Selecteer bestandstypen om te kopiëren", labelanchor="n"); filt.pack(fill="x", padx=8, pady=6)
             self.pdf_var = tk.IntVar(); self.step_var = tk.IntVar(); self.dxf_var = tk.IntVar(); self.dwg_var = tk.IntVar()
-            tk.Checkbutton(filt, text="PDF (.pdf)", variable=self.pdf_var).pack(anchor="w", padx=8)
-            tk.Checkbutton(filt, text="STEP (.step, .stp)", variable=self.step_var).pack(anchor="w", padx=8)
-            tk.Checkbutton(filt, text="DXF (.dxf)", variable=self.dxf_var).pack(anchor="w", padx=8)
-            tk.Checkbutton(filt, text="DWG (.dwg)", variable=self.dwg_var).pack(anchor="w", padx=8)
+            ttk.Checkbutton(filt, text="PDF (.pdf)", variable=self.pdf_var).pack(anchor="w", padx=8)
+            ttk.Checkbutton(filt, text="STEP (.step, .stp)", variable=self.step_var).pack(anchor="w", padx=8)
+            ttk.Checkbutton(filt, text="DXF (.dxf)", variable=self.dxf_var).pack(anchor="w", padx=8)
+            ttk.Checkbutton(filt, text="DWG (.dwg)", variable=self.dwg_var).pack(anchor="w", padx=8)
 
             # BOM controls
-            bf = tk.Frame(self); bf.pack(fill="x", padx=8, pady=6)
-            tk.Button(bf, text="Laad BOM (CSV/Excel)", command=self._load_bom).pack(side="left", padx=6)
-            tk.Button(bf, text="Leveranciers Beheer", command=self._open_suppliers).pack(side="left", padx=6)
-            tk.Button(bf, text="Controleer Bestanden", command=self._check_files).pack(side="left", padx=6)
+            bf = ttk.Frame(self); bf.pack(fill="x", padx=8, pady=6)
+            ttk.Button(bf, text="Laad BOM (CSV/Excel)", command=self._load_bom, style="Miami.TButton").pack(side="left", padx=6)
+            ttk.Button(bf, text="Leveranciers Beheer", command=self._open_suppliers, style="Miami.TButton").pack(side="left", padx=6)
+            ttk.Button(bf, text="Controleer Bestanden", command=self._check_files, style="Miami.TButton").pack(side="left", padx=6)
 
             # Tree
             style = ttk.Style(self)
@@ -387,13 +405,13 @@ def start_gui():
             self.tree.pack(fill="both", expand=True, padx=8, pady=6)
 
             # Actions
-            act = tk.Frame(self); act.pack(fill="x", padx=8, pady=8)
-            tk.Button(act, text="Kopieer zonder submappen", command=self._copy_flat).pack(side="left", padx=6)
-            tk.Button(act, text="Kopieer per productie + bestelbonnen", command=self._copy_per_prod).pack(side="left", padx=6)
+            act = ttk.Frame(self); act.pack(fill="x", padx=8, pady=8)
+            ttk.Button(act, text="Kopieer zonder submappen", command=self._copy_flat, style="Miami.TButton").pack(side="left", padx=6)
+            ttk.Button(act, text="Kopieer per productie + bestelbonnen", command=self._copy_per_prod, style="Miami.TButton").pack(side="left", padx=6)
 
             # Status
             self.status_var = tk.StringVar(value="Klaar")
-            tk.Label(self, textvariable=self.status_var, anchor="w").pack(fill="x", padx=8, pady=(0,8))
+            ttk.Label(self, textvariable=self.status_var, anchor="w").pack(fill="x", padx=8, pady=(0,8))
 
         def _open_suppliers(self):
             SuppliersManagerWin(self, self.db, on_change=lambda: None)


### PR DESCRIPTION
## Summary
- define Miami Vice color constants and global ttk styles
- swap widgets to themed ttk versions and apply custom 'Miami.TButton'
- ensure all windows inherit the new palette

## Testing
- `python -m py_compile gui.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68a6e672d1e08323a5d5fd457f29938d