### PR TITLE
Add supplier contact details to order documents

### DIFF
--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 
 import pandas as pd
+import openpyxl
 
 from models import Supplier, Client
 from suppliers_db import SuppliersDB
@@ -89,6 +90,19 @@ def run_tests() -> int:
         assert os.path.exists(os.path.join(prod_folder, "PN1.stp"))
         xlsx = [f for f in os.listdir(prod_folder) if f.lower().endswith(".xlsx")]
         assert xlsx, "Excel bestelbon niet aangemaakt"
+        wb = openpyxl.load_workbook(os.path.join(prod_folder, xlsx[0]))
+        ws = wb.active
+        assert ws["A1"].value == "Bedrijf" and ws["B1"].value == client.name
+        assert ws["A6"].value == "Leverancier" and ws["B6"].value == "ACME"
+        assert ws["A7"].value == "Adres"
+        assert (
+            ws["B7"].value == "Teststraat 1 bus 2, BE-2000 Antwerpen, BE"
+        )
+        assert ws["A8"].value == "BTW" and ws["B8"].value == "BE123"
+        assert ws["A9"].value == "E-mail" and ws["B9"].value == "x@y.z"
+        assert ws["A10"].value == "Tel" and ws["B10"].value == "+32 123"
+        pdfs = [f for f in os.listdir(prod_folder) if f.lower().endswith(".pdf")]
+        assert pdfs, "PDF bestelbon niet aangemaakt"
     print("All tests passed.")
     return 0
 


### PR DESCRIPTION
## Summary
- Expand PDF order generation with full supplier address and contact details
- Add header with company and supplier info to Excel order sheets
- Ensure order generation passes company and supplier fields through to document writers

## Testing
- `python -m py_compile orders.py tests/self_test.py`
- `python -m tests.self_test` *(fails: No module named 'pandas')*
- `pip install pandas openpyxl` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68ad8d2cf7648322a8c7962600a97d6c