### PR TITLE
Persist supplier defaults across runs

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -321,13 +321,14 @@ def start_gui():
                     break
 
         def _confirm(self):
-            result = {}
+            """Collect selected suppliers per production and return via callback."""
+            sel_map: Dict[str, str] = {}
             for prod, combo in self.rows:
                 typed = combo.get()
                 s = self._resolve_text_to_supplier(typed)
                 if s:
-                    result[prod] = s.supplier
-            self.callback(result, True if self.remember_var.get() else False)
+                    sel_map[prod] = s.supplier
+            self.callback(sel_map, bool(self.remember_var.get()))
             self.destroy()
 
     class App(tk.Tk):

--- a/orders.py
+++ b/orders.py
@@ -292,7 +292,8 @@ def copy_per_production_and_orders(
         except Exception as e:
             print(f"[WAARSCHUWING] PDF mislukt voor {prod}: {e}", file=sys.stderr)
 
-    if remember_defaults:
-        db.save(SUPPLIERS_DB_FILE)
+    # Persist any (possibly unchanged) supplier defaults so that callers can rely on
+    # the database reflecting the latest state on disk.
+    db.save(SUPPLIERS_DB_FILE)
 
     return count_copied, chosen

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -1,0 +1,53 @@
+import os
+import pandas as pd
+from models import Supplier
+from suppliers_db import SuppliersDB
+from orders import copy_per_production_and_orders
+
+
+def test_defaults_persist(tmp_path, monkeypatch):
+    # Ensure suppliers DB file is created inside temporary directory
+    monkeypatch.chdir(tmp_path)
+
+    # Setup supplier database with two suppliers
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+    db.upsert(Supplier.from_any({"supplier": "BETA"}))
+
+    # Create source and destination directories
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir(); dst.mkdir()
+
+    # Create dummy files for each part
+    (src / "PN1.pdf").write_text("dummy")
+    (src / "PN2.pdf").write_text("dummy")
+
+    # BOM with two productions
+    bom_df = pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1},
+        {"PartNumber": "PN2", "Description": "", "Production": "Plasma", "Aantal": 1},
+    ])
+
+    overrides = {"Laser": "ACME", "Plasma": "BETA"}
+
+    # Run the copy and order generation, remembering defaults
+    cnt, chosen = copy_per_production_and_orders(
+        str(src),
+        str(dst),
+        bom_df,
+        [".pdf"],
+        db,
+        overrides,
+        True,
+    )
+
+    assert cnt == 2
+    assert chosen == overrides
+
+    # Defaults should be updated in memory
+    assert db.defaults_by_production == overrides
+
+    # Reload from disk and ensure defaults persisted
+    db2 = SuppliersDB.load()
+    assert db2.defaults_by_production == overrides


### PR DESCRIPTION
## Summary
- Ensure supplier selections map production to supplier before confirmation
- Always save supplier database after copy to persist defaults
- Add regression test verifying defaults are written and reloaded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68ad8d25497083229129cb5ddcb92bba