### PR TITLE
Improve PDF export and file verification

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -31,7 +31,7 @@ def _pn_wrap_25(pn: str) -> str:
 
 def _material_nowrap(s: str) -> str:
     """Voorkom wrapping in Paragraph: vervang spaties door &nbsp;."""
-    return _to_str(s).replace(" ", "&nbsp;").replace("-", "&#8209;")  # non-breaking hyphen
+    return _to_str(s).replace(" ", "&nbsp;")
 
 
 def _build_file_index(source_folder: str, selected_exts: List[str]) -> Dict[str, List[str]]:

--- a/tests/test_file_check.py
+++ b/tests/test_file_check.py
@@ -1,0 +1,22 @@
+import os
+import pandas as pd
+from helpers import _build_file_index
+
+def test_all_required_exts(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    # PN1 has both pdf and stp
+    (src / "PN1.pdf").write_text("pdf")
+    (src / "PN1.stp").write_text("step")
+    # PN2 only pdf
+    (src / "PN2.pdf").write_text("pdf")
+    df = pd.DataFrame({"PartNumber": ["PN1", "PN2"]})
+    idx = _build_file_index(str(src), [".pdf", ".step", ".stp"])
+    groups = [{".step", ".stp"}, {".pdf"}]
+    statuses = []
+    for pn in df["PartNumber"]:
+        hits = idx.get(pn, [])
+        hit_exts = {os.path.splitext(h)[1].lower() for h in hits}
+        all_present = all(any(ext in hit_exts for ext in g) for g in groups)
+        statuses.append(all_present)
+    assert statuses == [True, False]


### PR DESCRIPTION
## Summary
- Expand PDF material column to use spare space and parse quantities robustly
- Allow choosing no supplier and skip order docs when none is selected
- Require all selected file types to exist with checkmark/cross indicators
- Fix non-breaking hyphen causing black boxes and add tests for file type checks

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `python -m pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68ad96801e2c83228267f42f2b38014f