### PR TITLE
Improve file check UI and supplier defaults

### DIFF
--- a/bom.py
+++ b/bom.py
@@ -96,7 +96,7 @@ def load_bom(path: str) -> pd.DataFrame:
                 return low[n.lower()]
         return None
 
-    aantal_col = find_any(["Aantal", "Qty", "Quantity", "Stuks"])
+    aantal_col = find_any(["Aantal", "Qty", "Qty.", "Quantity", "Stuks"])
 
     opp_col = find_any(
         [

--- a/orders.py
+++ b/orders.py
@@ -291,6 +291,8 @@ def pick_supplier_for_production(
             if s.supplier.lower() == name.lower():
                 return s
         return Supplier(supplier=name)
+    if prod.strip().lower() in {"dummy part", "nan", "spare part"}:
+        return Supplier(supplier="")
     default = db.get_default(prod)
     if default:
         for s in sups:


### PR DESCRIPTION
## Summary
- Center status icons and add scrollbars to BOM and part-number widgets
- Link missing-status icons to open SolidWorks source files
- Auto-select '(geen)' for dummy/nan/spare productions and respect blank supplier choices
- Recognize `Qty.` in BOM and skip orders when no supplier chosen

## Testing
- `python -m py_compile gui.py bom.py orders.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68addc23d0248322a9e12444ea57ce15