### PR TITLE
Move zip option to actions frame

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -596,7 +596,6 @@ def start_gui():
             tk.Checkbutton(filt, text="STEP (.step, .stp)", variable=self.step_var).pack(anchor="w", padx=8)
             tk.Checkbutton(filt, text="DXF (.dxf)", variable=self.dxf_var).pack(anchor="w", padx=8)
             tk.Checkbutton(filt, text="DWG (.dwg)", variable=self.dwg_var).pack(anchor="w", padx=8)
-            tk.Checkbutton(filt, text="Zip per productie", variable=self.zip_var).pack(anchor="w", padx=8)
 
             # BOM controls
             bf = tk.Frame(main); bf.pack(fill="x", padx=8, pady=6)
@@ -637,6 +636,7 @@ def start_gui():
             act = tk.Frame(main); act.pack(fill="x", padx=8, pady=8)
             tk.Button(act, text="Kopieer zonder submappen", command=self._copy_flat).pack(side="left", padx=6)
             tk.Button(act, text="Kopieer per productie + bestelbonnen", command=self._copy_per_prod).pack(side="left", padx=6)
+            tk.Checkbutton(act, text="Zip per productie", variable=self.zip_var).pack(side="left", padx=6)
             tk.Button(act, text="Combine pdf", command=self._combine_pdf).pack(side="left", padx=6)
 
             # Status


### PR DESCRIPTION
## Summary
- Remove "Zip per productie" checkbox from file-type filters
- Add zip option to actions frame next to copy buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_b_68af056cfb888322aecf2f4cb7426916