### PR TITLE
Add PDF merging from source and GUI integration

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -16,6 +16,7 @@ from orders import (
     copy_per_production_and_orders,
     DEFAULT_FOOTER_NOTE,
     combine_pdfs_per_production,
+    combine_pdfs_from_source,
 )
 
 def start_gui():
@@ -837,22 +838,42 @@ def start_gui():
 
         def _combine_pdf(self):
             from tkinter import messagebox
-            if not self.dest_folder:
-                messagebox.showwarning("Let op", "Selecteer bestemmingsmap."); return
-            def work():
-                self.status_var.set("PDF's combineren...")
-                try:
-                    cnt = combine_pdfs_per_production(self.dest_folder)
-                except ModuleNotFoundError:
-                    self.status_var.set("PyPDF2 ontbreekt")
-                    messagebox.showwarning(
-                        "PyPDF2 ontbreekt",
-                        "Installeer PyPDF2 om PDF's te combineren.",
-                    )
-                    return
-                self.status_var.set(f"Gecombineerde pdf's: {cnt}")
-                messagebox.showinfo("Klaar", "PDF's gecombineerd.")
-            threading.Thread(target=work, daemon=True).start()
+            if self.dest_folder:
+                def work():
+                    self.status_var.set("PDF's combineren...")
+                    try:
+                        cnt = combine_pdfs_per_production(self.dest_folder)
+                    except ModuleNotFoundError:
+                        self.status_var.set("PyPDF2 ontbreekt")
+                        messagebox.showwarning(
+                            "PyPDF2 ontbreekt",
+                            "Installeer PyPDF2 om PDF's te combineren.",
+                        )
+                        return
+                    self.status_var.set(f"Gecombineerde pdf's: {cnt}")
+                    messagebox.showinfo("Klaar", "PDF's gecombineerd.")
+                threading.Thread(target=work, daemon=True).start()
+            elif self.source_folder and self.bom_df is not None:
+                def work():
+                    self.status_var.set("PDF's combineren...")
+                    try:
+                        cnt = combine_pdfs_from_source(
+                            self.source_folder, self.bom_df, self.source_folder
+                        )
+                    except ModuleNotFoundError:
+                        self.status_var.set("PyPDF2 ontbreekt")
+                        messagebox.showwarning(
+                            "PyPDF2 ontbreekt",
+                            "Installeer PyPDF2 om PDF's te combineren.",
+                        )
+                        return
+                    self.status_var.set(f"Gecombineerde pdf's: {cnt}")
+                    messagebox.showinfo("Klaar", "PDF's gecombineerd.")
+                threading.Thread(target=work, daemon=True).start()
+            else:
+                messagebox.showwarning(
+                    "Let op", "Selecteer bron + BOM of bestemmingsmap."
+                )
 
     App().mainloop()
 

--- a/tests/test_combine_pdfs.py
+++ b/tests/test_combine_pdfs.py
@@ -1,9 +1,10 @@
 import zipfile
 from pathlib import Path
 
+import pandas as pd
 from PyPDF2 import PdfWriter
 
-from orders import combine_pdfs_per_production
+from orders import combine_pdfs_per_production, combine_pdfs_from_source
 
 
 def _blank_pdf(path: Path) -> None:
@@ -38,6 +39,34 @@ def test_combine_handles_loose_files_and_zip(tmp_path):
     (dest / "empty").mkdir()
 
     count = combine_pdfs_per_production(str(dest), date)
+    out_dir = dest / "Combined pdf"
+
+    assert count == 2
+    assert sorted(p.name for p in out_dir.glob("*.pdf")) == [
+        "prod1_2023-01-01_combined.pdf",
+        "prod2_2023-01-01_combined.pdf",
+    ]
+
+
+def test_combine_from_source_without_copy(tmp_path):
+    source = tmp_path / "src"
+    dest = tmp_path / "out"
+    source.mkdir()
+    dest.mkdir()
+
+    for name in ["a.pdf", "b.pdf", "c.pdf", "d.pdf"]:
+        _blank_pdf(source / name)
+
+    bom_df = pd.DataFrame(
+        [
+            {"PartNumber": "a", "Production": "prod1"},
+            {"PartNumber": "b", "Production": "prod1"},
+            {"PartNumber": "c", "Production": "prod2"},
+            {"PartNumber": "d", "Production": "prod2"},
+        ]
+    )
+
+    count = combine_pdfs_from_source(str(source), bom_df, str(dest), "2023-01-01")
     out_dir = dest / "Combined pdf"
 
     assert count == 2


### PR DESCRIPTION
## Summary
- add `combine_pdfs_from_source` to merge PDFs per production straight from the source folder
- adjust GUI PDF combine logic to use new function when only a source folder is selected
- test direct source PDF combination

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68af0c6cd8948322bc97b74fd4c79b4e