### PR TITLE
Prioritize BOM-based PDF combining

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -838,11 +838,14 @@ def start_gui():
 
         def _combine_pdf(self):
             from tkinter import messagebox
-            if self.dest_folder:
+            if self.source_folder and self.bom_df is not None:
                 def work():
                     self.status_var.set("PDF's combineren...")
                     try:
-                        cnt = combine_pdfs_per_production(self.dest_folder)
+                        out_dir = self.dest_folder or self.source_folder
+                        cnt = combine_pdfs_from_source(
+                            self.source_folder, self.bom_df, out_dir
+                        )
                     except ModuleNotFoundError:
                         self.status_var.set("PyPDF2 ontbreekt")
                         messagebox.showwarning(
@@ -853,13 +856,11 @@ def start_gui():
                     self.status_var.set(f"Gecombineerde pdf's: {cnt}")
                     messagebox.showinfo("Klaar", "PDF's gecombineerd.")
                 threading.Thread(target=work, daemon=True).start()
-            elif self.source_folder and self.bom_df is not None:
+            elif self.dest_folder:
                 def work():
                     self.status_var.set("PDF's combineren...")
                     try:
-                        cnt = combine_pdfs_from_source(
-                            self.source_folder, self.bom_df, self.source_folder
-                        )
+                        cnt = combine_pdfs_per_production(self.dest_folder)
                     except ModuleNotFoundError:
                         self.status_var.set("PyPDF2 ontbreekt")
                         messagebox.showwarning(

--- a/tests/test_combine_pdfs.py
+++ b/tests/test_combine_pdfs.py
@@ -75,3 +75,32 @@ def test_combine_from_source_without_copy(tmp_path):
         "prod2_2023-01-01_combined.pdf",
     ]
 
+
+def test_combine_from_source_to_dest_without_copy(tmp_path):
+    source = tmp_path / "src"
+    dest = tmp_path / "out"
+    source.mkdir()
+    dest.mkdir()
+
+    for name in ["a.pdf", "b.pdf", "c.pdf", "d.pdf"]:
+        _blank_pdf(source / name)
+
+    bom_df = pd.DataFrame(
+        [
+            {"PartNumber": "a", "Production": "prod1"},
+            {"PartNumber": "b", "Production": "prod1"},
+            {"PartNumber": "c", "Production": "prod2"},
+            {"PartNumber": "d", "Production": "prod2"},
+        ]
+    )
+
+    count = combine_pdfs_from_source(str(source), bom_df, str(dest), "2023-01-01")
+    out_dir = dest / "Combined pdf"
+
+    assert count == 2
+    assert sorted(p.name for p in out_dir.glob("*.pdf")) == [
+        "prod1_2023-01-01_combined.pdf",
+        "prod2_2023-01-01_combined.pdf",
+    ]
+    assert sorted(p.name for p in dest.iterdir()) == ["Combined pdf"]
+


### PR DESCRIPTION
## Summary
- prioritize BOM-based PDF combination before destination folder option
- output combined PDFs to a specified destination when available
- verify combining from source directly to destination without pre-copy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68af0f98e4488322960d5485ec5dc6ea