### PR TITLE
Add delivery address selection for orders

### DIFF
--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -1,0 +1,66 @@
+import os
+import json
+from dataclasses import asdict
+from typing import List, Optional
+
+from models import DeliveryAddress
+
+DELIVERY_ADDRESSES_DB_FILE = "delivery_addresses_db.json"
+
+
+class DeliveryAddressesDB:
+    def __init__(self, addresses: Optional[List[DeliveryAddress]] = None):
+        self.addresses: List[DeliveryAddress] = addresses or []
+
+    @staticmethod
+    def load(path: str = DELIVERY_ADDRESSES_DB_FILE) -> "DeliveryAddressesDB":
+        if not os.path.exists(path):
+            return DeliveryAddressesDB()
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            recs = data.get("addresses", data if isinstance(data, list) else [])
+            addresses = []
+            for rec in recs:
+                try:
+                    addresses.append(DeliveryAddress.from_any(rec))
+                except Exception:
+                    pass
+            return DeliveryAddressesDB(addresses)
+        except Exception:
+            return DeliveryAddressesDB()
+
+    def save(self, path: str = DELIVERY_ADDRESSES_DB_FILE) -> None:
+        data = {"addresses": [asdict(a) for a in self.addresses]}
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+
+    def addresses_sorted(self) -> List[DeliveryAddress]:
+        return sorted(self.addresses, key=lambda a: a.name.lower())
+
+    def display_name(self, addr: DeliveryAddress) -> str:
+        return addr.name
+
+    def _idx_by_name(self, name: str) -> int:
+        for i, a in enumerate(self.addresses):
+            if a.name.strip().lower() == str(name).strip().lower():
+                return i
+        return -1
+
+    def upsert(self, addr: DeliveryAddress) -> None:
+        i = self._idx_by_name(addr.name)
+        if i >= 0:
+            self.addresses[i] = addr
+        else:
+            self.addresses.append(addr)
+
+    def remove(self, name: str) -> bool:
+        i = self._idx_by_name(name)
+        if i >= 0:
+            self.addresses.pop(i)
+            return True
+        return False
+
+    def get(self, name: str) -> Optional[DeliveryAddress]:
+        i = self._idx_by_name(name)
+        return self.addresses[i] if i >= 0 else None

--- a/models.py
+++ b/models.py
@@ -198,3 +198,21 @@ class Client:
             email=_to_str(norm.get("email")).strip() or None if ("email" in norm) else None,
             favorite=bool(fav),
         )
+
+
+@dataclass
+class DeliveryAddress:
+    """Simple record representing a delivery/shipping address."""
+
+    name: str
+    address: Optional[str] = None
+
+    @staticmethod
+    def from_any(d: dict) -> "DeliveryAddress":
+        """Create an instance from a loosely-typed dictionary."""
+
+        name = _to_str(d.get("name") or d.get("naam")).strip()
+        addr = _to_str(d.get("address") or d.get("adres")).strip()
+        if not name:
+            raise ValueError("Delivery address name is missing in record.")
+        return DeliveryAddress(name=name, address=addr or None)


### PR DESCRIPTION
## Summary
- support managing delivery addresses with new DeliveryAddressesDB and GUI manager
- allow selecting delivery address per production in supplier popup
- propagate selected delivery address into generated Excel and PDF order headers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b035f69ff88322bd2a29f611dc90e6