### PR TITLE
Add doc type to order document generation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -261,6 +261,7 @@ def cli_copy_per_prod(args):
         args.remember_defaults,
         client=client,
         footer_note=args.note or DEFAULT_FOOTER_NOTE,
+        doc_type=args.doc_type,
     )
     print("Gekopieerd:", cnt)
     for k, v in chosen.items():
@@ -347,6 +348,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--note", help="Optioneel voetnootje op de bestelbon", default=""
     )
     cpp.add_argument("--client", help="Gebruik opdrachtgever met deze naam")
+    cpp.add_argument(
+        "--doc-type",
+        choices=["bestelbon", "offerte"],
+        default="bestelbon",
+        help="Type document om te genereren",
+    )
 
     return p
 

--- a/gui.py
+++ b/gui.py
@@ -593,6 +593,7 @@ def start_gui():
             filt = tk.LabelFrame(main, text="Selecteer bestandstypen om te kopiëren", labelanchor="n"); filt.pack(fill="x", padx=8, pady=6)
             self.pdf_var = tk.IntVar(); self.step_var = tk.IntVar(); self.dxf_var = tk.IntVar(); self.dwg_var = tk.IntVar()
             self.zip_var = tk.IntVar()
+            self.doc_type_var = tk.StringVar(value="bestelbon")
             tk.Checkbutton(filt, text="PDF (.pdf)", variable=self.pdf_var).pack(anchor="w", padx=8)
             tk.Checkbutton(filt, text="STEP (.step, .stp)", variable=self.step_var).pack(anchor="w", padx=8)
             tk.Checkbutton(filt, text="DXF (.dxf)", variable=self.dxf_var).pack(anchor="w", padx=8)
@@ -636,7 +637,14 @@ def start_gui():
             # Actions
             act = tk.Frame(main); act.pack(fill="x", padx=8, pady=8)
             tk.Button(act, text="Kopieer zonder submappen", command=self._copy_flat).pack(side="left", padx=6)
-            tk.Button(act, text="Kopieer per productie + bestelbonnen", command=self._copy_per_prod).pack(side="left", padx=6)
+            ttk.Combobox(
+                act,
+                textvariable=self.doc_type_var,
+                state="readonly",
+                values=["bestelbon", "offerte"],
+                width=12,
+            ).pack(side="left", padx=6)
+            tk.Button(act, text="Kopieer per productie + documenten", command=self._copy_per_prod).pack(side="left", padx=6)
             tk.Checkbutton(act, text="Zip per productie", variable=self.zip_var).pack(side="left", padx=6)
             tk.Button(act, text="Combine pdf", command=self._combine_pdf).pack(side="left", padx=6)
 
@@ -823,16 +831,19 @@ def start_gui():
             prods = sorted(set((str(r.get("Production") or "").strip() or "_Onbekend") for _, r in self.bom_df.iterrows()))
             def on_sel(sel_map: Dict[str,str], remember: bool):
                 def work():
-                    self.status_var.set("Kopiëren & bestelbonnen maken...")
+                    dtype = self.doc_type_var.get()
+                    doc_label = "Offertes" if dtype == "offerte" else "Bestelbonnen"
+                    self.status_var.set(f"Kopiëren & {doc_label} maken...")
                     client = self.client_db.get(self.client_var.get().replace("★ ", "", 1))
                     cnt, chosen = copy_per_production_and_orders(
                         self.source_folder, self.dest_folder, self.bom_df, exts, self.db, sel_map, remember,
                         client=client,
                         footer_note=DEFAULT_FOOTER_NOTE,
-                        zip_parts=bool(self.zip_var.get())
+                        zip_parts=bool(self.zip_var.get()),
+                        doc_type=dtype,
                     )
                     self.status_var.set(f"Klaar. Gekopieerd: {cnt}. Leveranciers: {chosen}")
-                    messagebox.showinfo("Klaar", "Bestelbonnen aangemaakt.")
+                    messagebox.showinfo("Klaar", f"{doc_label} aangemaakt.")
                 threading.Thread(target=work, daemon=True).start()
             SupplierSelectionPopup(self, prods, self.db, on_sel)
 

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -92,15 +92,16 @@ def run_tests() -> int:
         assert xlsx, "Excel bestelbon niet aangemaakt"
         wb = openpyxl.load_workbook(os.path.join(prod_folder, xlsx[0]))
         ws = wb.active
-        assert ws["A1"].value == "Bedrijf" and ws["B1"].value == client.name
-        assert ws["A6"].value == "Leverancier" and ws["B6"].value == "ACME"
-        assert ws["A7"].value == "Adres"
+        assert ws["A1"].value == "Bestelbon productie" and ws["B1"].value == "Laser"
+        assert ws["A3"].value == "Bedrijf" and ws["B3"].value == client.name
+        assert ws["A8"].value == "Leverancier" and ws["B8"].value == "ACME"
+        assert ws["A9"].value == "Adres"
         assert (
-            ws["B7"].value == "Teststraat 1 bus 2, BE-2000 Antwerpen, BE"
+            ws["B9"].value == "Teststraat 1 bus 2, BE-2000 Antwerpen, BE"
         )
-        assert ws["A8"].value == "BTW" and ws["B8"].value == "BE123"
-        assert ws["A9"].value == "E-mail" and ws["B9"].value == "x@y.z"
-        assert ws["A10"].value == "Tel" and ws["B10"].value == "+32 123"
+        assert ws["A10"].value == "BTW" and ws["B10"].value == "BE123"
+        assert ws["A11"].value == "E-mail" and ws["B11"].value == "x@y.z"
+        assert ws["A12"].value == "Tel" and ws["B12"].value == "+32 123"
         pdfs = [f for f in os.listdir(prod_folder) if f.lower().endswith(".pdf")]
         assert pdfs, "PDF bestelbon niet aangemaakt"
     print("All tests passed.")


### PR DESCRIPTION
## Summary
- Allow switching between bestelbon and offerte outputs
- Name generated files and titles based on document type
- Expose document type in CLI and GUI options

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `pip install pandas openpyxl reportlab` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b035e3619c8322bd50d9a2f091151e