### PR TITLE
Add document type option to copy-per-prod command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ python cli.py clients add "Klant BV" \
     --email "info@klant.be"
 ```
 
+### Bestelbon of offerte genereren
+
+Met het commando `copy-per-prod` worden bestanden per productie gekopieerd en wordt automatisch een document aangemaakt. Via de optie `--doc-type` bepaal je of er een **bestelbon** (standaard) of een **offerte** gemaakt wordt:
+
+```
+python cli.py copy-per-prod --source bron --dest doel --bom bom.csv --exts pdf \
+    --doc-type offerte
+```
+

--- a/cli.py
+++ b/cli.py
@@ -261,6 +261,7 @@ def cli_copy_per_prod(args):
         args.remember_defaults,
         client=client,
         footer_note=args.note or DEFAULT_FOOTER_NOTE,
+        doc_type=args.doc_type,
     )
     print("Gekopieerd:", cnt)
     for k, v in chosen.items():
@@ -347,6 +348,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--note", help="Optioneel voetnootje op de bestelbon", default=""
     )
     cpp.add_argument("--client", help="Gebruik opdrachtgever met deze naam")
+    cpp.add_argument(
+        "--doc-type",
+        choices=["bestelbon", "offerte"],
+        default="bestelbon",
+        help="Documenttype voor bestelbonnen of offertes",
+    )
 
     return p
 


### PR DESCRIPTION
## Summary
- Allow choosing the document type ('bestelbon' or 'offerte') via a new `--doc-type` CLI option.
- Pass the selected document type to the order generation logic.
- Document how to select the document type in the README.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Cannot connect to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b040716ec88322b6bc06291f148c8c