### PR TITLE
Add offerteaanvraag document type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ python cli.py clients add "Klant BV" \
     --email "info@klant.be"
 ```
 
-### Bestelbon of offerte genereren
+### Bestelbon, offerte of offerteaanvraag genereren
 
-Met het commando `copy-per-prod` worden bestanden per productie gekopieerd en wordt automatisch een document aangemaakt. Via de optie `--doc-type` bepaal je of er een **bestelbon** (standaard) of een **offerte** gemaakt wordt:
+Met het commando `copy-per-prod` worden bestanden per productie gekopieerd en wordt automatisch een document aangemaakt. Via de optie `--doc-type` bepaal je of er een **bestelbon** (standaard), een **offerte** of een **offerteaanvraag** gemaakt wordt:
 
 ```
 python cli.py copy-per-prod --source bron --dest doel --bom bom.csv --exts pdf \
-    --doc-type offerte
+    --doc-type offerteaanvraag
 ```
 

--- a/cli.py
+++ b/cli.py
@@ -350,9 +350,9 @@ def build_parser() -> argparse.ArgumentParser:
     cpp.add_argument("--client", help="Gebruik opdrachtgever met deze naam")
     cpp.add_argument(
         "--doc-type",
-        choices=["bestelbon", "offerte"],
+        choices=["bestelbon", "offerte", "offerteaanvraag"],
         default="bestelbon",
-        help="Documenttype voor bestelbonnen of offertes",
+        help="Documenttype voor bestelbonnen, offertes of offerteaanvragen",
     )
 
     return p

--- a/gui.py
+++ b/gui.py
@@ -760,7 +760,13 @@ def start_gui():
             act = tk.Frame(main); act.pack(fill="x", padx=8, pady=8)
             tk.Button(act, text="Kopieer zonder submappen", command=self._copy_flat).pack(side="left", padx=6)
             tk.Button(act, text="Kopieer per productie + bestelbonnen", command=self._copy_per_prod).pack(side="left", padx=6)
-            ttk.Combobox(act, textvariable=self.doc_type_var, values=["bestelbon", "offerte"], state="readonly", width=10).pack(side="left", padx=6)
+            ttk.Combobox(
+                act,
+                textvariable=self.doc_type_var,
+                values=["bestelbon", "offerte", "offerteaanvraag"],
+                state="readonly",
+                width=10,
+            ).pack(side="left", padx=6)
             tk.Checkbutton(act, text="Zip per productie", variable=self.zip_var).pack(side="left", padx=6)
             tk.Button(act, text="Combine pdf", command=self._combine_pdf).pack(side="left", padx=6)
 
@@ -957,7 +963,13 @@ def start_gui():
                         doc_type=self.doc_type_var.get(),
                     )
                     self.status_var.set(f"Klaar. Gekopieerd: {cnt}. Leveranciers: {chosen}")
-                    doc_name = "Offertes" if self.doc_type_var.get() == "offerte" else "Bestelbonnen"
+                    doc_type = self.doc_type_var.get()
+                    if doc_type == "offerte":
+                        doc_name = "Offertes"
+                    elif doc_type == "offerteaanvraag":
+                        doc_name = "Offerteaanvragen"
+                    else:
+                        doc_name = "Bestelbonnen"
                     messagebox.showinfo("Klaar", f"{doc_name} aangemaakt.")
                 threading.Thread(target=work, daemon=True).start()
             SupplierSelectionPopup(self, prods, self.db, on_sel)

--- a/orders.py
+++ b/orders.py
@@ -126,8 +126,15 @@ def generate_pdf_order_platypus(
         addr_parts.append(supplier.land)
     full_addr = ", ".join(addr_parts)
 
-    doc_title = "Offerte" if doc_type == "offerte" else "Bestelbon"
-    supp_label = "Offerte bij:" if doc_type == "offerte" else "Besteld bij:"
+    if doc_type == "offerte":
+        doc_title = "Offerte"
+        supp_label = "Offerte bij:"
+    elif doc_type == "offerteaanvraag":
+        doc_title = "Offerteaanvraag"
+        supp_label = "Offerte aangevraagd bij:"
+    else:
+        doc_title = "Bestelbon"
+        supp_label = "Besteld bij:"
     supp_lines = [f"<b>{supp_label}</b> {supplier.supplier}"]
     if full_addr:
         supp_lines.append(full_addr)
@@ -414,7 +421,12 @@ def copy_per_production_and_orders(
             "email": client.email if client else "",
         }
         if supplier.supplier:
-            doc_prefix = "Offerte" if doc_type == "offerte" else "Bestelbon"
+            if doc_type == "offerte":
+                doc_prefix = "Offerte"
+            elif doc_type == "offerteaanvraag":
+                doc_prefix = "Offerteaanvraag"
+            else:
+                doc_prefix = "Bestelbon"
             excel_path = os.path.join(prod_folder, f"{doc_prefix}_{prod}_{today}.xlsx")
             write_order_excel(excel_path, items, company, supplier)
 
@@ -507,7 +519,7 @@ def combine_pdfs_per_production(dest: str, date_str: str | None = None) -> int:
         pdfs = [
             f
             for f in os.listdir(prod_path)
-            if f.lower().endswith(".pdf") and not f.startswith(("Bestelbon_", "Offerte_"))
+            if f.lower().endswith(".pdf") and not f.startswith(("Bestelbon_", "Offerte_", "Offerteaanvraag_"))
         ]
         if pdfs:
             merger = PdfMerger()
@@ -523,7 +535,7 @@ def combine_pdfs_per_production(dest: str, date_str: str | None = None) -> int:
                     name
                     for name in zf.namelist()
                     if name.lower().endswith(".pdf")
-                    and not os.path.basename(name).startswith(("Bestelbon_", "Offerte_"))
+                    and not os.path.basename(name).startswith(("Bestelbon_", "Offerte_", "Offerteaanvraag_"))
                 ]
                 if not zip_pdfs:
                     continue

--- a/tests/test_combine_pdfs.py
+++ b/tests/test_combine_pdfs.py
@@ -2,7 +2,7 @@ import zipfile
 from pathlib import Path
 
 import pandas as pd
-from PyPDF2 import PdfWriter
+from PyPDF2 import PdfWriter, PdfReader
 
 from orders import combine_pdfs_per_production, combine_pdfs_from_source
 
@@ -103,4 +103,23 @@ def test_combine_from_source_to_dest_without_copy(tmp_path):
         "prod2_2023-01-01_combined.pdf",
     ]
     assert sorted(p.name for p in dest.iterdir()) == ["Combined pdf"]
+
+
+def test_combine_skips_order_documents(tmp_path):
+    dest = tmp_path
+    date = "2023-01-01"
+    prod1 = dest / "prod1"
+    prod1.mkdir()
+    _blank_pdf(prod1 / "a.pdf")
+    _blank_pdf(prod1 / "Bestelbon_x.pdf")
+    _blank_pdf(prod1 / "Offerte_x.pdf")
+    _blank_pdf(prod1 / "Offerteaanvraag_x.pdf")
+
+    count = combine_pdfs_per_production(str(dest), date)
+    out_dir = dest / "Combined pdf"
+    pdf_path = out_dir / "prod1_2023-01-01_combined.pdf"
+    reader = PdfReader(str(pdf_path))
+
+    assert count == 1
+    assert len(reader.pages) == 1
 

--- a/tests/test_doc_type_offerteaanvraag.py
+++ b/tests/test_doc_type_offerteaanvraag.py
@@ -1,0 +1,39 @@
+import os
+import pandas as pd
+
+from models import Supplier
+from suppliers_db import SuppliersDB
+from orders import copy_per_production_and_orders
+
+
+def test_offerteaanvraag_prefix(tmp_path):
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir(); dst.mkdir()
+
+    (src / "PN1.pdf").write_text("dummy")
+
+    bom_df = pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}
+    ])
+
+    overrides = {"Laser": "ACME"}
+
+    copy_per_production_and_orders(
+        str(src),
+        str(dst),
+        bom_df,
+        [".pdf"],
+        db,
+        overrides,
+        False,
+        doc_type="offerteaanvraag",
+    )
+
+    prod_folder = dst / "Laser"
+    files = list(os.listdir(prod_folder))
+    assert any(f.startswith("Offerteaanvraag_") and f.endswith(".pdf") for f in files)
+    assert any(f.startswith("Offerteaanvraag_") and f.endswith(".xlsx") for f in files)


### PR DESCRIPTION
## Summary
- support `offerteaanvraag` document type in CLI, GUI, and order generation
- document the new option and update file name filters
- add tests for `offerteaanvraag` and order document filtering

## Testing
- `pip install -r requirements.txt`
- `pip install pandas openpyxl` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b04bad509c8322a28af3b962da4bb2