### PR TITLE
Add delivery address selection and propagate to generated documents

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -258,6 +258,7 @@ def cli_copy_per_prod(args):
         exts,
         db,
         override_map,
+        {},
         args.remember_defaults,
         client=client,
         footer_note=args.note or DEFAULT_FOOTER_NOTE,

--- a/orders.py
+++ b/orders.py
@@ -55,7 +55,7 @@ from helpers import (
     _material_nowrap,
     _build_file_index,
 )
-from models import Supplier, Client
+from models import Supplier, Client, DeliveryAddress
 from suppliers_db import SuppliersDB, SUPPLIERS_DB_FILE
 from bom import load_bom  # noqa: F401 - imported for module dependency
 
@@ -78,6 +78,7 @@ def generate_pdf_order_platypus(
     path: str,
     company_info: Dict[str, str],
     supplier: Supplier,
+    delivery_address: DeliveryAddress | None,
     production: str,
     items: List[Dict[str, str]],
     footer_note: str = "",
@@ -145,6 +146,18 @@ def generate_pdf_order_platypus(
     story.append(Paragraph("<br/>".join(company_lines), text_style))
     story.append(Spacer(0, 6))
     story.append(Paragraph("<br/>".join(supp_lines), text_style))
+    if delivery_address:
+        addr_lines = [f"<b>Leveringsadres:</b> {delivery_address.name}"]
+        if delivery_address.address:
+            addr_lines.append(delivery_address.address)
+        if delivery_address.contact:
+            addr_lines.append(f"Contact: {delivery_address.contact}")
+        if delivery_address.phone:
+            addr_lines.append(f"Tel: {delivery_address.phone}")
+        if delivery_address.email:
+            addr_lines.append(f"E-mail: {delivery_address.email}")
+        story.append(Spacer(0, 6))
+        story.append(Paragraph("<br/>".join(addr_lines), text_style))
     story.append(Spacer(0, 10))
 
     # Headers and data
@@ -254,6 +267,7 @@ def write_order_excel(
     items: List[Dict[str, str]],
     company_info: Dict[str, str] | None = None,
     supplier: Supplier | None = None,
+    delivery_address: DeliveryAddress | None = None,
 ) -> None:
     """Write order information to an Excel file with header info."""
     df = pd.DataFrame(
@@ -291,6 +305,17 @@ def write_order_excel(
                 ("BTW", supplier.btw or ""),
                 ("E-mail", supplier.sales_email or ""),
                 ("Tel", supplier.phone or ""),
+                ("", ""),
+            ]
+        )
+    if delivery_address:
+        header_lines.extend(
+            [
+                ("Leveringsadres", delivery_address.name),
+                ("Adres", delivery_address.address or ""),
+                ("Contact", delivery_address.contact or ""),
+                ("Tel", delivery_address.phone or ""),
+                ("E-mail", delivery_address.email or ""),
                 ("", ""),
             ]
         )
@@ -340,6 +365,7 @@ def copy_per_production_and_orders(
     selected_exts: List[str],
     db: SuppliersDB,
     override_map: Dict[str, str],
+    addr_map: Dict[str, DeliveryAddress] | None = None,
     remember_defaults: bool,
     client: Client | None = None,
     footer_note: str = "",
@@ -393,6 +419,9 @@ def copy_per_production_and_orders(
         chosen[prod] = supplier.supplier
         if remember_defaults and supplier.supplier not in ("", "Onbekend"):
             db.set_default(prod, supplier.supplier)
+        delivery_addr = None
+        if addr_map:
+            delivery_addr = addr_map.get(prod)
 
         items = []
         for row in rows:
@@ -416,7 +445,7 @@ def copy_per_production_and_orders(
         if supplier.supplier:
             doc_prefix = "Offerte" if doc_type == "offerte" else "Bestelbon"
             excel_path = os.path.join(prod_folder, f"{doc_prefix}_{prod}_{today}.xlsx")
-            write_order_excel(excel_path, items, company, supplier)
+            write_order_excel(excel_path, items, company, supplier, delivery_addr)
 
             pdf_path = os.path.join(prod_folder, f"{doc_prefix}_{prod}_{today}.pdf")
             try:
@@ -424,6 +453,7 @@ def copy_per_production_and_orders(
                     pdf_path,
                     company,
                     supplier,
+                    delivery_addr,
                     prod,
                     items,
                     footer_note=footer_note or DEFAULT_FOOTER_NOTE,

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -79,6 +79,7 @@ def run_tests() -> int:
             [".pdf", ".stp"],
             db,
             {},
+            {},
             True,
             client=client,
             footer_note=DEFAULT_FOOTER_NOTE,

--- a/tests/test_address_in_docs.py
+++ b/tests/test_address_in_docs.py
@@ -1,0 +1,57 @@
+import pandas as pd
+import openpyxl
+import pytest
+
+from models import Supplier, DeliveryAddress
+from suppliers_db import SuppliersDB
+from orders import copy_per_production_and_orders, REPORTLAB_OK
+
+
+def test_delivery_address_in_documents(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir(); dst.mkdir()
+    (src / "PN1.pdf").write_text("dummy")
+    bom_df = pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}
+    ])
+    addr = DeliveryAddress.from_any({
+        "name": "Magazijn",
+        "address": "Straat 5, 1000 Brussel",
+        "contact": "Jan",
+        "phone": "012345",
+        "email": "jan@example.com",
+    })
+    overrides = {"Laser": "ACME"}
+    addr_map = {"Laser": addr}
+    cnt, chosen = copy_per_production_and_orders(
+        str(src),
+        str(dst),
+        bom_df,
+        [".pdf"],
+        db,
+        overrides,
+        addr_map,
+        False,
+    )
+    assert cnt == 1
+    prod_dir = dst / "Laser"
+    xlsx = next(prod_dir.glob("*.xlsx"))
+    wb = openpyxl.load_workbook(xlsx)
+    ws = wb.active
+    found = False
+    for i in range(1, 20):
+        if ws[f"A{i}"].value == "Leveringsadres":
+            assert ws[f"B{i}"].value == addr.name
+            assert ws[f"B{i+1}"].value == addr.address
+            found = True
+            break
+    assert found, "Leveringsadres niet gevonden in Excel"
+    if REPORTLAB_OK:
+        pdf = next(prod_dir.glob("*.pdf"))
+        content = pdf.read_bytes().decode("latin1")
+        assert addr.address in content
+        assert addr.name in content

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -39,6 +39,7 @@ def test_defaults_persist(tmp_path, monkeypatch):
         [".pdf"],
         db,
         overrides,
+        {},
         True,
     )
 


### PR DESCRIPTION
## Summary
- Allow choosing delivery addresses per production and pass them through the workflow
- Include selected address in generated Excel and PDF headers
- Test that chosen delivery address appears in created documents

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b04bbb11588322b39a215f65ed6efa