### PR TITLE
Raise informative DB load errors

### DIFF
--- a/clients_db.py
+++ b/clients_db.py
@@ -1,11 +1,14 @@
-import os
 import json
+import logging
+import os
 from dataclasses import asdict
 from typing import List, Optional
 
 from models import Client
 
 CLIENTS_DB_FILE = "clients_db.json"
+
+logger = logging.getLogger(__name__)
 
 
 class ClientsDB:
@@ -30,8 +33,10 @@ class ClientsDB:
                 except Exception:
                     pass
             return ClientsDB(clients)
-        except Exception:
-            return ClientsDB()
+        except Exception as exc:
+            msg = f"Failed to load clients database from {path}: {exc}"
+            logger.error(msg)
+            raise RuntimeError(msg) from exc
 
     def save(self, path: str = CLIENTS_DB_FILE) -> None:
         data = {"clients": [asdict(c) for c in self.clients]}

--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -1,11 +1,14 @@
-import os
 import json
+import logging
+import os
 from dataclasses import asdict
 from typing import List, Optional
 
 from models import DeliveryAddress
 
 DELIVERY_ADDRESSES_DB_FILE = "delivery_addresses_db.json"
+
+logger = logging.getLogger(__name__)
 
 
 class DeliveryAddressesDB:
@@ -30,8 +33,10 @@ class DeliveryAddressesDB:
                 except Exception:
                     pass
             return DeliveryAddressesDB(addrs)
-        except Exception:
-            return DeliveryAddressesDB()
+        except Exception as exc:
+            msg = f"Failed to load delivery addresses database from {path}: {exc}"
+            logger.error(msg)
+            raise RuntimeError(msg) from exc
 
     def save(self, path: str = DELIVERY_ADDRESSES_DB_FILE) -> None:
         data = {"addresses": [asdict(a) for a in self.addresses]}

--- a/suppliers_db.py
+++ b/suppliers_db.py
@@ -1,11 +1,14 @@
-import os
 import json
+import logging
+import os
 from dataclasses import asdict
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 from models import Supplier
 
 SUPPLIERS_DB_FILE = "suppliers_db.json"
+
+logger = logging.getLogger(__name__)
 
 
 class SuppliersDB:
@@ -32,8 +35,10 @@ class SuppliersDB:
                     pass
             defaults = data.get("defaults_by_production", {}) or {}
             return SuppliersDB(sups, defaults)
-        except Exception:
-            return SuppliersDB()
+        except Exception as exc:
+            msg = f"Failed to load suppliers database from {path}: {exc}"
+            logger.error(msg)
+            raise RuntimeError(msg) from exc
 
     def save(self, path: str = SUPPLIERS_DB_FILE) -> None:
         data = {

--- a/tests/test_db_error_handling.py
+++ b/tests/test_db_error_handling.py
@@ -1,0 +1,33 @@
+import json
+import pytest
+
+from clients_db import ClientsDB, CLIENTS_DB_FILE
+from suppliers_db import SuppliersDB, SUPPLIERS_DB_FILE
+from delivery_addresses_db import (
+    DeliveryAddressesDB,
+    DELIVERY_ADDRESSES_DB_FILE,
+)
+
+
+def _write_corrupt(path):
+    path.write_text('{ bad json', encoding='utf-8')
+
+
+@pytest.mark.parametrize(
+    "cls, filename",
+    [
+        (ClientsDB, CLIENTS_DB_FILE),
+        (SuppliersDB, SUPPLIERS_DB_FILE),
+        (DeliveryAddressesDB, DELIVERY_ADDRESSES_DB_FILE),
+    ],
+)
+def test_load_corrupt_json(tmp_path, monkeypatch, cls, filename):
+    monkeypatch.chdir(tmp_path)
+    file_path = tmp_path / filename
+    _write_corrupt(file_path)
+    with pytest.raises(RuntimeError) as exc_info:
+        cls.load(filename)
+    msg = str(exc_info.value)
+    assert filename in msg
+    # ensure original JSON error is attached
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)


### PR DESCRIPTION
## Summary
- log and raise runtime error on clients DB load failures
- log and raise runtime error on suppliers DB load failures
- log and raise runtime error on delivery addresses DB load failures
- test error handling for corrupt JSON files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest tests/test_db_error_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b0633f43548322960aba86cd1e5780