### PR TITLE
Separate messagebox warnings from return statements

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -770,12 +770,15 @@ def start_gui():
         def _check_files(self):
             from tkinter import messagebox
             if self.bom_df is None:
-                messagebox.showwarning("Let op", "Laad eerst een BOM."); return
+                messagebox.showwarning("Let op", "Laad eerst een BOM.")
+                return
             if not self.source_folder:
-                messagebox.showwarning("Let op", "Selecteer een bronmap."); return
+                messagebox.showwarning("Let op", "Selecteer een bronmap.")
+                return
             exts = self._selected_exts()
             if not exts:
-                messagebox.showwarning("Let op", "Selecteer minstens één bestandstype."); return
+                messagebox.showwarning("Let op", "Selecteer minstens één bestandstype.")
+                return
             self.status_var.set("Bezig met controleren...")
             self.update_idletasks()
             idx = _build_file_index(self.source_folder, exts)
@@ -821,7 +824,8 @@ def start_gui():
             from tkinter import messagebox
             exts = self._selected_exts()
             if not exts or not self.source_folder or not self.dest_folder:
-                messagebox.showwarning("Let op", "Selecteer bron, bestemming en extensies."); return
+                messagebox.showwarning("Let op", "Selecteer bron, bestemming en extensies.")
+                return
             def work():
                 self.status_var.set("Kopiëren...")
                 idx = _build_file_index(self.source_folder, exts)
@@ -837,10 +841,12 @@ def start_gui():
         def _copy_per_prod(self):
             from tkinter import messagebox
             if self.bom_df is None:
-                messagebox.showwarning("Let op", "Laad eerst een BOM."); return
+                messagebox.showwarning("Let op", "Laad eerst een BOM.")
+                return
             exts = self._selected_exts()
             if not exts or not self.source_folder or not self.dest_folder:
-                messagebox.showwarning("Let op", "Selecteer bron, bestemming en extensies."); return
+                messagebox.showwarning("Let op", "Selecteer bron, bestemming en extensies.")
+                return
 
 
 


### PR DESCRIPTION
## Summary
- Refactor GUI checks to place `return` on its own line after `messagebox.showwarning`
- Keep early exits readable in file checks and copy helpers

## Testing
- `ruff check gui.py` *(fails: unused imports and existing style issues)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b06348e5848322a03adafaae13d299