### PR TITLE
Log import errors and add strict mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -113,7 +113,7 @@ def cli_suppliers(args):
         except Exception:
             df = read_csv_flex(path)
         changed = 0
-        for _, row in df.iterrows():
+        for idx, row in df.iterrows():
             raw_name = _to_str(row.get("Supplier")).strip()
             if not raw_name or raw_name == "-":
                 continue
@@ -131,8 +131,13 @@ def cli_suppliers(args):
                     s.phone = args.phone
                 db.upsert(s)
                 changed += 1
-            except Exception:
-                pass
+            except Exception as e:
+                print(
+                    f"Rij {idx}: fout bij importeren van {row.to_dict()} -> {e}"
+                )
+                if getattr(args, "strict", False):
+                    print("Import afgebroken wegens fout.")
+                    return 1
         db.save(SUPPLIERS_DB_FILE)
         print(f"Verwerkt (upsert): {changed}")
         return 0
@@ -304,6 +309,11 @@ def build_parser() -> argparse.ArgumentParser:
     ip.add_argument("--adres-2", dest="adres_2", help="Fallback adresregel 2")
     ip.add_argument("--email", help="Fallback e-mail adres voor verkoop")
     ip.add_argument("--tel", dest="phone", help="Fallback telefoonnummer")
+    ip.add_argument(
+        "--strict",
+        action="store_true",
+        help="Breek af bij fouten tijdens import",
+    )
     ssp.add_parser("clear")
 
     cp = sub.add_parser("clients", help="Beheer opdrachtgevers")

--- a/clients_db.py
+++ b/clients_db.py
@@ -24,13 +24,14 @@ class ClientsDB:
             else:
                 recs = data.get("clients", [])
             clients = []
-            for rec in recs:
+            for idx, rec in enumerate(recs):
                 try:
                     clients.append(Client.from_any(rec))
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(f"Fout bij client record {idx}: {e}; data={rec}")
             return ClientsDB(clients)
-        except Exception:
+        except Exception as e:
+            print(f"Fout bij laden van opdrachtgevers: {e}")
             return ClientsDB()
 
     def save(self, path: str = CLIENTS_DB_FILE) -> None:

--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -24,13 +24,16 @@ class DeliveryAddressesDB:
             else:
                 recs = data.get("addresses", [])
             addrs = []
-            for rec in recs:
+            for idx, rec in enumerate(recs):
                 try:
                     addrs.append(DeliveryAddress.from_any(rec))
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(
+                        f"Fout bij leveradres record {idx}: {e}; data={rec}"
+                    )
             return DeliveryAddressesDB(addrs)
-        except Exception:
+        except Exception as e:
+            print(f"Fout bij laden van leveradressen: {e}")
             return DeliveryAddressesDB()
 
     def save(self, path: str = DELIVERY_ADDRESSES_DB_FILE) -> None:

--- a/suppliers_db.py
+++ b/suppliers_db.py
@@ -25,14 +25,17 @@ class SuppliersDB:
                 return SuppliersDB(sups, {})
             sups_raw = data.get("suppliers", [])
             sups = []
-            for rec in sups_raw:
+            for idx, rec in enumerate(sups_raw):
                 try:
                     sups.append(Supplier.from_any(rec))
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(
+                        f"Fout bij leverancier record {idx}: {e}; data={rec}"
+                    )
             defaults = data.get("defaults_by_production", {}) or {}
             return SuppliersDB(sups, defaults)
-        except Exception:
+        except Exception as e:
+            print(f"Fout bij laden van leveranciers: {e}")
             return SuppliersDB()
 
     def save(self, path: str = SUPPLIERS_DB_FILE) -> None:


### PR DESCRIPTION
## Summary
- report record index and error cause when loading clients, suppliers, and delivery addresses
- log row details during CSV supplier import and optionally abort with --strict

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b06346ce2c8322933b5f7f1263ab77