### PR TITLE
Add default value for remember_defaults

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -379,7 +379,7 @@ def copy_per_production_and_orders(
     selected_exts: List[str],
     db: SuppliersDB,
     override_map: Dict[str, str],
-    remember_defaults: bool,
+    remember_defaults: bool = False,
     addr_map: Dict[str, DeliveryAddress] | None = None,
     client: Client | None = None,
     footer_note: str = "",


### PR DESCRIPTION
## Summary
- provide a default value for `remember_defaults` in `copy_per_production_and_orders` to ensure parameters without defaults precede those with defaults

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b07078dcb883229e284bbb9dbe700e