### PR TITLE
Add DeliveryAddress dataclass with normalization utility

### DIFF
--- a/models.py
+++ b/models.py
@@ -202,3 +202,59 @@ class Client:
 
 @dataclass
 class DeliveryAddress:
+    name: str
+    address: Optional[str] = None
+    contact: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+    favorite: bool = False
+
+    def __str__(self) -> str:
+        parts = [self.name]
+        if self.address:
+            parts.append(self.address)
+        return ", ".join(parts)
+
+    @staticmethod
+    def from_any(d: dict) -> "DeliveryAddress":
+        key_map = {
+            "name": "name",
+            "naam": "name",
+            "address": "address",
+            "adres": "address",
+            "leveradres": "address",
+            "leveringsadres": "address",
+            "contact": "contact",
+            "contactpersoon": "contact",
+            "phone": "phone",
+            "telefoon": "phone",
+            "tel": "phone",
+            "email": "email",
+            "e-mail": "email",
+            "mail": "email",
+            "favorite": "favorite",
+            "favoriet": "favorite",
+            "fav": "favorite",
+        }
+        norm = {}
+        for k, v in d.items():
+            lk = str(k).strip().lower()
+            if lk in key_map:
+                norm[key_map[lk]] = v
+
+        name = str(norm.get("name") or d.get("name") or "").strip()
+        if not name:
+            raise ValueError("Delivery address name is missing in record.")
+
+        fav = norm.get("favorite", d.get("favorite", False))
+        if isinstance(fav, str):
+            fav = fav.strip().lower() in ("1", "true", "yes", "y", "ja")
+
+        return DeliveryAddress(
+            name=name,
+            address=_to_str(norm.get("address")).strip() or None if ("address" in norm) else None,
+            contact=_to_str(norm.get("contact")).strip() or None if ("contact" in norm) else None,
+            phone=_to_str(norm.get("phone")).strip() or None if ("phone" in norm) else None,
+            email=_to_str(norm.get("email")).strip() or None if ("email" in norm) else None,
+            favorite=bool(fav),
+        )


### PR DESCRIPTION
## Summary
- define `DeliveryAddress` dataclass with contact info fields
- add `from_any` helper to normalize varied keys into canonical form
- provide simple string representation for addresses

## Testing
- `pytest tests/test_delivery_addresses_db.py -q` *(fails: `delivery_addresses_db.py` SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_b_68b07661336c83228a22caf410fcf329