### PR TITLE
feat: allow address map and remember defaults

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -264,7 +264,7 @@ def cli_copy_per_prod(args):
         db,
         override_map,
         args.remember_defaults,
-        {},
+        addr_map={},
         client=client,
         footer_note=args.note or DEFAULT_FOOTER_NOTE,
         doc_type=args.doc_type,


### PR DESCRIPTION
## Summary
- support address mappings in `copy_per_production_and_orders`
- optionally persist chosen suppliers with `remember_defaults`
- update CLI invocation for new address map parameter

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b07682cd208322a31866956fa43ac0