### PR TITLE
Fix DeliveryAddress normalization and closing

### DIFF
--- a/models.py
+++ b/models.py
@@ -213,7 +213,16 @@ class DeliveryAddress:
     def from_any(d: dict) -> "DeliveryAddress":
         key_map = {
             "name": "name",
-
+            "address": "address",
+            "adres": "address",
+            "contact": "contact",
+            "contactpersoon": "contact",
+            "contact person": "contact",
+            "phone": "phone",
+            "phone number": "phone",
+            "telefoon": "phone",
+            "telefoon nummer": "phone",
+            "tel": "phone",
             "email": "email",
             "e-mail": "email",
             "mail": "email",
@@ -221,7 +230,7 @@ class DeliveryAddress:
             "favoriet": "favorite",
             "fav": "favorite",
         }
-
+        norm = {}
         for k, v in d.items():
             lk = str(k).strip().lower()
             if lk in key_map:
@@ -239,4 +248,5 @@ class DeliveryAddress:
             phone=_to_str(norm.get("phone")).strip() or None if ("phone" in norm) else None,
             email=_to_str(norm.get("email")).strip() or None if ("email" in norm) else None,
             favorite=bool(fav),
+        )
 


### PR DESCRIPTION
## Summary
- add address, contact, phone and favorite keys to DeliveryAddress normalization map
- initialize `norm` before parsing records
- properly close `return DeliveryAddress(...)`

## Testing
- `pytest` *(fails: No module named 'pandas'; syntax errors in clients_db.py and delivery_addresses_db.py)*

------
https://chatgpt.com/codex/tasks/task_b_68b07a9925108322a52edbb8c6262cfe