### PR TITLE
Normalize delivery address records on load

### DIFF
--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -27,7 +27,15 @@ class DeliveryAddressesDB:
                 recs = data
             else:
                 recs = data.get("addresses", [])
-
+            for idx, rec in enumerate(recs):
+                try:
+                    addr = DeliveryAddress.from_any(rec)
+                    addresses.append(addr)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning("Invalid delivery address record %s: %s", idx, e)
+        except Exception:
+            logger.exception("Error loading delivery addresses DB")
+        return DeliveryAddressesDB(addresses)
 
     def save(self, path: str = DELIVERY_ADDRESSES_DB_FILE) -> None:
         data = {"addresses": [asdict(a) for a in self.addresses]}


### PR DESCRIPTION
## Summary
- normalize delivery address DB records via `DeliveryAddress.from_any`
- warn when invalid records are encountered
- always return `DeliveryAddressesDB` populated with parsed addresses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas'; SyntaxError in models and clients DB)*

------
https://chatgpt.com/codex/tasks/task_b_68b07aa6257483229d5fa033983e7d3a