### PR TITLE
Remove unused delivery_map parameter

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -487,7 +487,6 @@ def copy_per_production_and_orders(
     override_map: Dict[str, str],
     remember_defaults: bool = False,
     addr_map: Dict[str, DeliveryAddress] | None = None,
-    delivery_map: Dict[str, str] | None = None,
     client: Client | None = None,
     footer_note: str = "",
     zip_parts: bool = False,


### PR DESCRIPTION
## Summary
- drop obsolete `delivery_map` argument from `copy_per_production_and_orders`

## Testing
- `python -m py_compile orders.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas'; SyntaxError in clients_db.py)*

------
https://chatgpt.com/codex/tasks/task_b_68b07abc916c8322b8492f7196afc964