### PR TITLE
Refactor clients DB load error handling

### DIFF
--- a/clients_db.py
+++ b/clients_db.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 from dataclasses import asdict
 from typing import List, Optional
@@ -8,7 +7,6 @@ from models import Client
 
 CLIENTS_DB_FILE = "clients_db.json"
 
-logger = logging.getLogger(__name__)
 
 
 class ClientsDB:
@@ -32,9 +30,6 @@ class ClientsDB:
                     clients.append(Client.from_any(rec))
                 except Exception as e:
                     print(f"Fout bij client record {idx}: {e}; data={rec}")
-        except Exception:
-            logger.exception("Error loading clients DB")
-        finally:
             return ClientsDB(clients)
         except Exception as e:
             raise RuntimeError(f"Fout bij laden van {path}") from e


### PR DESCRIPTION
## Summary
- return `ClientsDB` directly inside load try block
- raise `RuntimeError` when clients DB loading fails

## Testing
- `python -m py_compile clients_db.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python main.py --cmd clients list` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b07dd7393483229b6ed92548eb9214