### PR TITLE
Replace client field with remarks for delivery addresses

### DIFF
--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -23,7 +23,6 @@ class DeliveryAddressesDB:
                     DeliveryAddress(
                         name=c.name,
                         address=c.address,
-                        client=c.name,
                         favorite=c.favorite,
                     )
                 )
@@ -43,6 +42,8 @@ class DeliveryAddressesDB:
             addresses = []
             for rec in recs:
                 try:
+                    if isinstance(rec, dict) and "client" in rec:
+                        rec = {k: v for k, v in rec.items() if k != "client"}
                     addresses.append(DeliveryAddress.from_any(rec))
                 except Exception:
                     pass
@@ -66,7 +67,7 @@ class DeliveryAddressesDB:
             return self.addresses_sorted()
         res = []
         for a in self.addresses:
-            hay = " ".join([a.name or "", a.address or "", a.client or ""]).lower()
+            hay = " ".join([a.name or "", a.address or "", a.remarks or ""]).lower()
             if q in hay:
                 res.append(a)
         res.sort(key=lambda a: (not a.favorite, a.name.lower()))

--- a/gui.py
+++ b/gui.py
@@ -178,7 +178,7 @@ def start_gui():
             self.db = db
             self.on_change = on_change
 
-            cols = ("Naam", "Adres", "Klant")
+            cols = ("Naam", "Adres", "Opmerkingen")
             self.tree = ttk.Treeview(self, columns=cols, show="headings", selectmode="browse")
             for c in cols:
                 self.tree.heading(c, text=c)
@@ -199,7 +199,7 @@ def start_gui():
                 self.tree.delete(it)
             for idx, a in enumerate(self.db.addresses_sorted()):
                 name = self.db.display_name(a)
-                vals = (name, a.address or "", a.client or "")
+                vals = (name, a.address or "", a.remarks or "")
                 tag = "odd" if idx % 2 == 0 else "even"
                 self.tree.insert("", "end", values=vals, tags=(tag,))
             self.tree.tag_configure("odd", background=TREE_ODD_BG)
@@ -218,7 +218,7 @@ def start_gui():
             fields = [
                 ("Naam", "name"),
                 ("Adres", "address"),
-                ("Klant", "client"),
+                ("Opmerkingen", "remarks"),
             ]
             entries = {}
             for i, (lbl, key) in enumerate(fields):

--- a/models.py
+++ b/models.py
@@ -204,7 +204,7 @@ class Client:
 class DeliveryAddress:
     name: str
     address: Optional[str] = None
-    client: Optional[str] = None
+    remarks: Optional[str] = None
     favorite: bool = False
 
     @staticmethod
@@ -214,8 +214,9 @@ class DeliveryAddress:
             "naam": "name",
             "address": "address",
             "adres": "address",
-            "client": "client",
-            "klant": "client",
+            "remarks": "remarks",
+            "opmerking": "remarks",
+            "opmerkingen": "remarks",
             "favorite": "favorite",
             "favoriet": "favorite",
             "fav": "favorite",
@@ -234,6 +235,6 @@ class DeliveryAddress:
         return DeliveryAddress(
             name=name,
             address=_to_str(norm.get("address")).strip() or None if ("address" in norm) else None,
-            client=_to_str(norm.get("client")).strip() or None if ("client" in norm) else None,
+            remarks=_to_str(norm.get("remarks")).strip() or None if ("remarks" in norm) else None,
             favorite=bool(fav),
         )


### PR DESCRIPTION
## Summary
- replace DeliveryAddress.client with remarks field and support multiple keys when importing
- migrate database and lookup logic to use remarks instead of client
- update delivery address manager GUI to show and edit remarks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b3547787f483228e841eedf6caac1d