### PR TITLE
Allow clearing delivery address fields

### DIFF
--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -87,9 +87,11 @@ class DeliveryAddressesDB:
         if i >= 0:
             cur = self.addresses[i]
             for f in asdict(addr):
-                val = getattr(addr, f)
-                if val not in (None, ""):
-                    setattr(cur, f, val)
+                # Renaming addresses is not supported; skip updating the name
+                if f == "name":
+                    continue
+                # Always overwrite existing values, even with None/"" to clear fields
+                setattr(cur, f, getattr(addr, f))
         else:
             self.addresses.append(addr)
 

--- a/gui.py
+++ b/gui.py
@@ -232,7 +232,8 @@ def start_gui():
             tk.Checkbutton(win, text="Favoriet", variable=fav_var).grid(row=len(fields), column=1, sticky="w", padx=4, pady=2)
 
             def _save():
-                rec = {k: e.get().strip() for k, e in entries.items()}
+                # Convert blank strings to None so cleared fields overwrite old data
+                rec = {k: (e.get().strip() or None) for k, e in entries.items()}
                 rec["favorite"] = fav_var.get()
                 if not rec["name"]:
                     messagebox.showwarning("Let op", "Naam is verplicht.", parent=win)

--- a/tests/test_delivery_address_clear.py
+++ b/tests/test_delivery_address_clear.py
@@ -1,0 +1,26 @@
+from delivery_addresses_db import DeliveryAddressesDB, DELIVERY_DB_FILE
+from models import DeliveryAddress
+
+
+def test_clearing_remark_persists(tmp_path, monkeypatch):
+    """Removing the remark should overwrite previous data with None."""
+    # work inside temporary directory so we don't touch real files
+    monkeypatch.chdir(tmp_path)
+
+    # start with an address that has a remark
+    db = DeliveryAddressesDB([
+        DeliveryAddress(name="Test", address="Street", remarks="to clear"),
+    ])
+    db.save()  # create initial file
+
+    # simulate editing the address and clearing the remark
+    cleared = DeliveryAddress.from_any({"name": "Test", "address": "Street", "remarks": ""})
+    db.upsert(cleared)
+    db.save()
+
+    # reload and ensure the remark is gone
+    db2 = DeliveryAddressesDB.load(DELIVERY_DB_FILE)
+    addr = db2.get("Test")
+    assert addr is not None
+    assert addr.remarks is None
+


### PR DESCRIPTION
## Summary
- Overwrite existing delivery address fields even when set to blank or None
- Treat blank GUI entries as None so empty fields persist
- Add regression test ensuring cleared remarks are saved and reloaded

## Testing
- `pytest tests/test_delivery_address_clear.py -q`
- ⚠️ `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- ⚠️ `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b35b79698483228b682a3ffb89ea8c