### PR TITLE
Log JSON load errors and add test

### DIFF
--- a/clients_db.py
+++ b/clients_db.py
@@ -1,11 +1,14 @@
 import os
 import json
+import logging
 from dataclasses import asdict
 from typing import List, Optional
 
 from models import Client
 
 CLIENTS_DB_FILE = "clients_db.json"
+
+logger = logging.getLogger(__name__)
 
 
 class ClientsDB:
@@ -30,7 +33,8 @@ class ClientsDB:
                 except Exception:
                     pass
             return ClientsDB(clients)
-        except Exception:
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("Error loading clients DB: %s", exc)
             return ClientsDB()
 
     def save(self, path: str = CLIENTS_DB_FILE) -> None:

--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 from dataclasses import asdict
 from typing import List, Optional
 
@@ -7,6 +8,8 @@ from models import DeliveryAddress
 from clients_db import ClientsDB, CLIENTS_DB_FILE
 
 DELIVERY_DB_FILE = "delivery_addresses_db.json"
+
+logger = logging.getLogger(__name__)
 
 
 class DeliveryAddressesDB:
@@ -50,7 +53,8 @@ class DeliveryAddressesDB:
             if not addresses:
                 addresses = DeliveryAddressesDB._copy_from_clients()
             return DeliveryAddressesDB(addresses)
-        except Exception:
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("Error loading delivery addresses DB: %s", exc)
             return DeliveryAddressesDB(DeliveryAddressesDB._copy_from_clients())
 
     def save(self, path: str = DELIVERY_DB_FILE) -> None:

--- a/suppliers_db.py
+++ b/suppliers_db.py
@@ -1,11 +1,14 @@
 import os
 import json
+import logging
 from dataclasses import asdict
 from typing import List, Dict, Optional
 
 from models import Supplier
 
 SUPPLIERS_DB_FILE = "suppliers_db.json"
+
+logger = logging.getLogger(__name__)
 
 
 class SuppliersDB:
@@ -32,7 +35,8 @@ class SuppliersDB:
                     pass
             defaults = data.get("defaults_by_production", {}) or {}
             return SuppliersDB(sups, defaults)
-        except Exception:
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("Error loading suppliers DB: %s", exc)
             return SuppliersDB()
 
     def save(self, path: str = SUPPLIERS_DB_FILE) -> None:

--- a/tests/test_load_corrupt_json_logging.py
+++ b/tests/test_load_corrupt_json_logging.py
@@ -1,0 +1,19 @@
+import logging
+import pytest
+
+from suppliers_db import SuppliersDB
+from clients_db import ClientsDB
+from delivery_addresses_db import DeliveryAddressesDB
+
+
+@pytest.mark.parametrize("loader", [
+    SuppliersDB.load,
+    ClientsDB.load,
+    DeliveryAddressesDB.load,
+])
+def test_corrupted_json_logs_error(tmp_path, caplog, loader):
+    path = tmp_path / "data.json"
+    path.write_text("{bad json")
+    with caplog.at_level(logging.ERROR):
+        loader(str(path))
+    assert any("Error loading" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Log JSON parsing and OS errors when loading suppliers, clients, and delivery address databases instead of suppressing them.
- Add unit test ensuring corrupted JSON files trigger error logs.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b363a1ccd483228f2e3a9f1a61b652