### PR TITLE
Use Decimal for precise numeric formatting

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Dict
 import os
 from collections import defaultdict
+from decimal import Decimal, InvalidOperation
 
 
 def _to_str(x: Any) -> str:
@@ -15,9 +16,9 @@ def _num_to_2dec(val: Any) -> str:
     if "," in s and "." not in s:
         s = s.replace(",", ".")
     try:
-        f = float(s)
-        return f"{f:.2f}"
-    except Exception:
+        f = Decimal(s)
+        return str(f.quantize(Decimal("0.01")))
+    except InvalidOperation:
         return _to_str(val)
 
 

--- a/tests/test_num_to_2dec.py
+++ b/tests/test_num_to_2dec.py
@@ -1,0 +1,15 @@
+from helpers import _num_to_2dec
+
+
+def test_num_to_2dec_formats_comma_and_dot():
+    assert _num_to_2dec("1,23") == "1.23"
+    assert _num_to_2dec("1.23") == "1.23"
+
+
+def test_num_to_2dec_exact_rounding():
+    # Without Decimal this would yield '2.67'
+    assert _num_to_2dec("2.675") == "2.68"
+
+
+def test_num_to_2dec_invalid_returns_original():
+    assert _num_to_2dec("abc") == "abc"


### PR DESCRIPTION
## Summary
- switch helper number formatting to use Decimal with two-decimal quantization
- add tests verifying comma/dot input, accurate rounding and invalid input handling

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `pytest tests/test_num_to_2dec.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b363dea9c883229eac7ff1928d6f2c