### PR TITLE
Enable ZIP compression for part archives

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -366,7 +366,13 @@ def copy_per_production_and_orders(
         zf = None
         if zip_parts:
             zip_path = os.path.join(prod_folder, f"{prod}.zip")
-            zf = zipfile.ZipFile(zip_path, "w")
+            try:
+                zf = zipfile.ZipFile(
+                    zip_path, "w", compression=zipfile.ZIP_DEFLATED
+                )
+            except (RuntimeError, ValueError, AttributeError):
+                # ZIP_DEFLATED not supported; fall back to no compression
+                zf = zipfile.ZipFile(zip_path, "w")
 
         for row in rows:
             pn = str(row["PartNumber"])

--- a/tests/test_zip_compression.py
+++ b/tests/test_zip_compression.py
@@ -1,0 +1,46 @@
+import zipfile
+import pandas as pd
+
+from orders import copy_per_production_and_orders
+from suppliers_db import SuppliersDB
+
+
+def test_zipfile_compression(tmp_path):
+    if zipfile.zlib is None:
+        import pytest
+
+        pytest.skip("ZIP_DEFLATED not available")
+
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+
+    # create compressible files
+    for pn in ["PN1", "PN2"]:
+        (src / f"{pn}.txt").write_text("A" * 1000)
+
+    bom_df = pd.DataFrame(
+        [{"PartNumber": "PN1", "Production": "P1", "Aantal": 1},
+         {"PartNumber": "PN2", "Production": "P1", "Aantal": 1}]
+    )
+
+    db = SuppliersDB()
+    copy_per_production_and_orders(
+        str(src),
+        str(dst),
+        bom_df,
+        [".txt"],
+        db,
+        {},
+        False,
+        zip_parts=True,
+    )
+
+    compressed = dst / "P1" / "P1.zip"
+    uncompressed = dst / "P1" / "P1_uncompressed.zip"
+    with zipfile.ZipFile(uncompressed, "w", compression=zipfile.ZIP_STORED) as z:
+        for pn in ["PN1", "PN2"]:
+            z.write(src / f"{pn}.txt", arcname=f"{pn}.txt")
+
+    assert compressed.stat().st_size < uncompressed.stat().st_size


### PR DESCRIPTION
## Summary
- compress per-production ZIP archives using `ZIP_DEFLATED`
- fall back to uncompressed ZIP if deflate compression isn't available
- add regression test ensuring compressed archives are smaller

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b36408d350832290283833e7f90d3a