### PR TITLE
Forward delivery addresses to order generation

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1262,7 +1262,7 @@ def start_gui():
                         exts,
                         self.db,
                         sel_map,
-                        {},
+                        addr_map,
                         remember,
                         client=client,
                         footer_note=DEFAULT_FOOTER_NOTE,

--- a/tests/test_order_delivery_address.py
+++ b/tests/test_order_delivery_address.py
@@ -1,0 +1,59 @@
+import pandas as pd
+from openpyxl import load_workbook
+
+from models import Supplier, Client
+from suppliers_db import SuppliersDB
+from orders import copy_per_production_and_orders
+
+
+def test_delivery_address_used_in_order(tmp_path, monkeypatch):
+    """The selected delivery address should appear in the order document."""
+    # operate within temporary directory to avoid side effects
+    monkeypatch.chdir(tmp_path)
+
+    # supplier database with one supplier
+    db = SuppliersDB([Supplier.from_any({"supplier": "ACME"})])
+
+    # create source and destination directories
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+
+    # dummy source file
+    (src / "PN1.pdf").write_text("dummy")
+
+    # BOM with a single production entry
+    bom_df = pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1},
+    ])
+
+    supplier_map = {"Laser": "ACME"}
+    delivery_map = {"Laser": "Custom Street 5"}
+
+    client = Client.from_any({"name": "Client", "address": "Base Addr"})
+
+    cnt, chosen = copy_per_production_and_orders(
+        str(src),
+        str(dst),
+        bom_df,
+        [".pdf"],
+        db,
+        supplier_map,
+        delivery_map,
+        False,
+        client=client,
+    )
+
+    assert cnt == 1
+
+    # verify that the generated Excel order contains the chosen delivery address
+    prod_dir = dst / "Laser"
+    excel_files = list(prod_dir.glob("Bestelbon_Laser_*.xlsx"))
+    assert excel_files, "Order Excel file not created"
+
+    wb = load_workbook(excel_files[0])
+    ws = wb.active
+    # Address is the second header row, second column
+    assert ws.cell(row=2, column=2).value == "Custom Street 5"
+


### PR DESCRIPTION
## Summary
- ensure GUI passes selected delivery addresses to `copy_per_production_and_orders`
- add regression test verifying order document uses chosen delivery address

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b43fa49cac8322993c6f3a8156151f