### PR TITLE
Show delivery address on order documents

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -105,10 +105,13 @@ def generate_pdf_order_platypus(
     text_style.leading = 13
     small_style = ParagraphStyle("small", parent=text_style, fontSize=8.5, leading=10.5)
 
-    company_lines = [
-        f"<b>{company_info.get('name','')}</b>",
-        f"{company_info.get('address','')}",
-    ]
+    company_lines = [f"<b>{company_info.get('name','')}</b>"]
+    addr = company_info.get("address", "")
+    if addr:
+        company_lines.append(f"Adres: {addr}")
+    deliv = company_info.get("delivery", "")
+    if deliv:
+        company_lines.append(f"Leveradres: {deliv}")
     note = company_info.get("note")
     if note:
         company_lines.append(note)
@@ -271,6 +274,7 @@ def write_order_excel(
             [
                 ("Bedrijf", company_info.get("name", "")),
                 ("Adres", company_info.get("address", "")),
+                ("Leveradres", company_info.get("delivery", "")),
             ]
         )
         note = company_info.get("note")
@@ -424,20 +428,22 @@ def copy_per_production_and_orders(
                 }
             )
 
-        base_addr = client.address if client else ""
+        invoice_addr = client.address if client else ""
+        delivery_addr = invoice_addr
         note = ""
         override_addr = delivery_map.get(prod)
         if override_addr:
             if override_addr == "Zelf afhalen":
-                base_addr = ""
+                delivery_addr = "Zelf afhalen"
                 note = "Afhalen door klant"
             elif override_addr == "Adres volgt":
-                base_addr = "Adres volgt"
+                delivery_addr = "Adres volgt"
             else:
-                base_addr = override_addr
+                delivery_addr = override_addr
         company = {
             "name": client.name if client else "",
-            "address": base_addr,
+            "address": invoice_addr,
+            "delivery": delivery_addr,
             "vat": client.vat if client else "",
             "email": client.email if client else "",
             "note": note,

--- a/tests/test_order_delivery_address.py
+++ b/tests/test_order_delivery_address.py
@@ -47,13 +47,14 @@ def test_delivery_address_used_in_order(tmp_path, monkeypatch):
 
     assert cnt == 1
 
-    # verify that the generated Excel order contains the chosen delivery address
+    # verify that the generated Excel order contains invoice and delivery address
     prod_dir = dst / "Laser"
     excel_files = list(prod_dir.glob("Bestelbon_Laser_*.xlsx"))
     assert excel_files, "Order Excel file not created"
 
     wb = load_workbook(excel_files[0])
     ws = wb.active
-    # Address is the second header row, second column
-    assert ws.cell(row=2, column=2).value == "Custom Street 5"
+    # row 2 should contain the invoice address, row 3 the chosen delivery address
+    assert ws.cell(row=2, column=2).value == "Base Addr"
+    assert ws.cell(row=3, column=2).value == "Custom Street 5"
 


### PR DESCRIPTION
## Summary
- Include separate delivery address in generated orders and PDFs
- Preserve invoice address and note when an alternate delivery address is chosen
- Test invoice vs delivery address lines in order Excel output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas openpyxl -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b443c8cbbc8322972bc99c5da3ea3e