### PR TITLE
Preserve special delivery addresses in order docs

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -705,10 +705,10 @@ def start_gui():
                     if s:
                         sel_map[prod] = s.supplier
                 a_typed = addr_combo.get().strip()
-                if a_typed in ("Zelf afhalen", "Adres volgt", ""):
+                if not a_typed:
                     addr_map[prod] = ""
                 else:
-                    addr_map[prod] = self._addr_disp_to_addr.get(a_typed, "")
+                    addr_map[prod] = self._addr_disp_to_addr.get(a_typed, a_typed)
             self.callback(sel_map, addr_map, bool(self.remember_var.get()))
             self.destroy()
 
@@ -960,10 +960,10 @@ def start_gui():
                     if s:
                         sel_map[prod] = s.supplier
                 a_typed = addr_combo.get().strip()
-                if a_typed in ("Zelf afhalen", "Adres volgt", ""):
+                if not a_typed:
                     addr_map[prod] = ""
                 else:
-                    addr_map[prod] = self._addr_disp_to_addr.get(a_typed, "")
+                    addr_map[prod] = self._addr_disp_to_addr.get(a_typed, a_typed)
             self.callback(sel_map, addr_map, bool(self.remember_var.get()))
 
     class App(tk.Tk):

--- a/tests/test_order_delivery_address.py
+++ b/tests/test_order_delivery_address.py
@@ -7,7 +7,8 @@ from suppliers_db import SuppliersDB
 from orders import copy_per_production_and_orders
 
 
-def test_delivery_address_used_in_order(tmp_path, monkeypatch):
+@pytest.mark.parametrize("delivery_address", ["Custom Street 5", "Zelf afhalen", "Adres volgt"])
+def test_delivery_address_used_in_order(delivery_address, tmp_path, monkeypatch):
     """The selected delivery address should appear in the order document."""
     # operate within temporary directory to avoid side effects
     monkeypatch.chdir(tmp_path)
@@ -30,7 +31,7 @@ def test_delivery_address_used_in_order(tmp_path, monkeypatch):
     ])
 
     supplier_map = {"Laser": "ACME"}
-    delivery_map = {"Laser": "Custom Street 5"}
+    delivery_map = {"Laser": delivery_address}
 
     client = Client.from_any({"name": "Client", "address": "Base Addr"})
 
@@ -57,10 +58,11 @@ def test_delivery_address_used_in_order(tmp_path, monkeypatch):
     ws = wb.active
     # row 2 should contain the invoice address and the chosen delivery address in column 6
     assert ws.cell(row=2, column=2).value == "Base Addr"
-    assert ws.cell(row=2, column=6).value == "Custom Street 5"
+    assert ws.cell(row=2, column=6).value == delivery_address
 
 
-def test_pdf_delivery_address_in_right_column(tmp_path, monkeypatch):
+@pytest.mark.parametrize("delivery_address", ["Custom Street 5", "Zelf afhalen", "Adres volgt"])
+def test_pdf_delivery_address_in_right_column(delivery_address, tmp_path, monkeypatch):
     reportlab = pytest.importorskip("reportlab")
     from PyPDF2 import PdfReader
 
@@ -80,7 +82,7 @@ def test_pdf_delivery_address_in_right_column(tmp_path, monkeypatch):
     ])
 
     supplier_map = {"Laser": "ACME"}
-    delivery_map = {"Laser": "Custom Street 5"}
+    delivery_map = {"Laser": delivery_address}
 
     client = Client.from_any({"name": "Client", "address": "Base Addr"})
 
@@ -114,6 +116,6 @@ def test_pdf_delivery_address_in_right_column(tmp_path, monkeypatch):
     page.extract_text(visitor_text=visitor)
 
     inv_x = positions["Base Addr"][0]
-    del_x = positions["Custom Street 5"][0]
+    del_x = positions[delivery_address][0]
     assert del_x > inv_x
 


### PR DESCRIPTION
## Summary
- Ensure SupplierSelection dialogs keep non-empty delivery address selections, including "Zelf afhalen" and "Adres volgt"
- Extend order delivery tests to cover these special addresses in generated Excel and PDF files

## Testing
- `pip install pandas openpyxl reportlab` *(failed: Could not connect to proxy)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_order_delivery_address.py::test_delivery_address_used_in_order -q` *(failed: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b455dc6b8083228bf8adfde0da8745