### PR TITLE
Add document type selection per production

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -258,6 +258,7 @@ def cli_copy_per_prod(args):
         exts,
         db,
         override_map,
+        {},
         args.remember_defaults,
         client=client,
         footer_note=args.note or DEFAULT_FOOTER_NOTE,

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -79,6 +79,7 @@ def run_tests() -> int:
             [".pdf", ".stp"],
             db,
             {},
+            {},
             True,
             client=client,
             footer_note=DEFAULT_FOOTER_NOTE,

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -39,6 +39,7 @@ def test_defaults_persist(tmp_path, monkeypatch):
         [".pdf"],
         db,
         overrides,
+        {},
         True,
     )
 


### PR DESCRIPTION
## Summary
- Add per-production document type combobox to supplier selection GUI
- Pass chosen document types through to order creation
- Support different document types in order generation and PDF combining

## Testing
- `pytest tests/test_defaults_persist.py::test_defaults_persist -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b47b0958c883229667ef4d8518081e