### PR TITLE
Add delivery address selection

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -726,6 +726,12 @@ def start_gui():
             tk.Button(top, text="Beheer", command=lambda: self.nb.select(self.clients_frame)).grid(row=2, column=2, padx=4)
             self._refresh_clients_combo()
 
+            tk.Label(top, text="Leveradres:").grid(row=2, column=3, sticky="w")
+            self.delivery_var = tk.StringVar()
+            self.delivery_combo = ttk.Combobox(top, textvariable=self.delivery_var, state="readonly", width=40)
+            self.delivery_combo.grid(row=2, column=4, padx=4)
+            self._refresh_delivery_addresses()
+
             # Filters
             filt = tk.LabelFrame(main, text="Selecteer bestandstypen om te kopiëren", labelanchor="n"); filt.pack(fill="x", padx=8, pady=6)
             self.pdf_var = tk.IntVar(); self.step_var = tk.IntVar(); self.dxf_var = tk.IntVar(); self.dwg_var = tk.IntVar()
@@ -788,7 +794,12 @@ def start_gui():
                 self.client_combo.set(opts[0])
 
         def _refresh_delivery_addresses(self):
-            pass
+            addrs = self.delivery_db.addresses_sorted()
+            opts = [self.delivery_db.display_name(a) for a in addrs]
+            self.delivery_combo["values"] = opts
+            if opts:
+                fav = next((self.delivery_db.display_name(a) for a in addrs if a.favorite), None)
+                self.delivery_combo.set(fav or opts[0])
 
         def _pick_src(self):
             from tkinter import filedialog
@@ -967,6 +978,7 @@ def start_gui():
                 def work():
                     self.status_var.set("Kopiëren & bestelbonnen maken...")
                     client = self.client_db.get(self.client_var.get().replace("★ ", "", 1))
+                    delivery = self.delivery_db.get(self.delivery_var.get().replace("★ ", "", 1))
                     cnt, chosen = copy_per_production_and_orders(
                         self.source_folder,
                         self.dest_folder,
@@ -977,6 +989,7 @@ def start_gui():
                         doc_map,
                         remember,
                         client=client,
+                        delivery_addr=delivery,
                         footer_note=DEFAULT_FOOTER_NOTE,
                         zip_parts=bool(self.zip_var.get()),
                     )


### PR DESCRIPTION
## Summary
- Add Leveradres combobox to main GUI and populate from delivery address database, defaulting to favourite entries
- Pass selected delivery address into order generation and include it in generated Excel and PDF documents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b49a73ef98832297384443743e2c67