### PR TITLE
Add optional delivery address to order exports

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -726,6 +726,13 @@ def start_gui():
             tk.Button(top, text="Beheer", command=lambda: self.nb.select(self.clients_frame)).grid(row=2, column=2, padx=4)
             self._refresh_clients_combo()
 
+            tk.Label(top, text="Leveradres:").grid(row=3, column=0, sticky="w")
+            self.delivery_var = tk.StringVar()
+            self.delivery_combo = ttk.Combobox(top, textvariable=self.delivery_var, state="readonly", width=40)
+            self.delivery_combo.grid(row=3, column=1, padx=4)
+            tk.Button(top, text="Beheer", command=lambda: self.nb.select(self.delivery_frame)).grid(row=3, column=2, padx=4)
+            self._refresh_delivery_addresses()
+
             # Filters
             filt = tk.LabelFrame(main, text="Selecteer bestandstypen om te kopiëren", labelanchor="n"); filt.pack(fill="x", padx=8, pady=6)
             self.pdf_var = tk.IntVar(); self.step_var = tk.IntVar(); self.dxf_var = tk.IntVar(); self.dwg_var = tk.IntVar()
@@ -788,7 +795,12 @@ def start_gui():
                 self.client_combo.set(opts[0])
 
         def _refresh_delivery_addresses(self):
-            pass
+            opts = [
+                self.delivery_db.display_name(a) for a in self.delivery_db.addresses_sorted()
+            ]
+            self.delivery_combo["values"] = opts
+            if opts:
+                self.delivery_combo.set(opts[0])
 
         def _pick_src(self):
             from tkinter import filedialog
@@ -967,6 +979,7 @@ def start_gui():
                 def work():
                     self.status_var.set("Kopiëren & bestelbonnen maken...")
                     client = self.client_db.get(self.client_var.get().replace("★ ", "", 1))
+                    delivery = self.delivery_db.get(self.delivery_var.get().replace("★ ", "", 1))
                     cnt, chosen = copy_per_production_and_orders(
                         self.source_folder,
                         self.dest_folder,
@@ -977,6 +990,7 @@ def start_gui():
                         doc_map,
                         remember,
                         client=client,
+                        delivery=delivery,
                         footer_note=DEFAULT_FOOTER_NOTE,
                         zip_parts=bool(self.zip_var.get()),
                     )

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -82,6 +82,7 @@ def run_tests() -> int:
             {},
             True,
             client=client,
+            delivery=None,
             footer_note=DEFAULT_FOOTER_NOTE,
         )
         assert cnt == 2

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -41,6 +41,8 @@ def test_defaults_persist(tmp_path, monkeypatch):
         overrides,
         {},
         True,
+        client=None,
+        delivery=None,
     )
 
     assert cnt == 2

--- a/tests/test_delivery_address_output.py
+++ b/tests/test_delivery_address_output.py
@@ -1,0 +1,84 @@
+import os
+import pandas as pd
+import openpyxl
+import pytest
+from PyPDF2 import PdfReader
+
+from models import Supplier, DeliveryAddress
+from suppliers_db import SuppliersDB
+from orders import copy_per_production_and_orders
+
+
+def _setup_basic(tmp_path):
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "PN1.pdf").write_text("dummy")
+    bom_df = pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}
+    ])
+    return db, src, bom_df
+
+
+def test_delivery_address_present_absent(tmp_path):
+    reportlab = pytest.importorskip("reportlab")
+    db, src, bom_df = _setup_basic(tmp_path)
+
+    delivery = DeliveryAddress(name="Magazijn", address="Straat 1", remarks="achterdeur")
+
+    # With delivery address
+    dst1 = tmp_path / "dst1"
+    dst1.mkdir()
+    copy_per_production_and_orders(
+        str(src),
+        str(dst1),
+        bom_df,
+        [".pdf"],
+        db,
+        {},
+        {},
+        False,
+        client=None,
+        delivery=delivery,
+    )
+    prod_folder = dst1 / "Laser"
+    xlsx = next(f for f in os.listdir(prod_folder) if f.endswith(".xlsx"))
+    wb = openpyxl.load_workbook(prod_folder / xlsx)
+    ws = wb.active
+    col_a = [ws[f"A{i}"].value for i in range(1, 20)]
+    assert "Leveradres" in col_a
+    row = col_a.index("Leveradres") + 1
+    assert ws[f"B{row}"].value == "Magazijn"
+    assert ws[f"B{row+1}"].value == "Straat 1"
+    assert ws[f"B{row+2}"].value == "achterdeur"
+    pdf = next(f for f in os.listdir(prod_folder) if f.endswith(".pdf"))
+    reader = PdfReader(prod_folder / pdf)
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    assert "Leveradres: Magazijn" in text
+
+    # Without delivery address
+    dst2 = tmp_path / "dst2"
+    dst2.mkdir()
+    copy_per_production_and_orders(
+        str(src),
+        str(dst2),
+        bom_df,
+        [".pdf"],
+        db,
+        {},
+        {},
+        False,
+        client=None,
+        delivery=None,
+    )
+    prod_folder2 = dst2 / "Laser"
+    xlsx2 = next(f for f in os.listdir(prod_folder2) if f.endswith(".xlsx"))
+    wb2 = openpyxl.load_workbook(prod_folder2 / xlsx2)
+    ws2 = wb2.active
+    col_a2 = [ws2[f"A{i}"].value for i in range(1, 20)]
+    assert "Leveradres" not in col_a2
+    pdf2 = next(f for f in os.listdir(prod_folder2) if f.endswith(".pdf"))
+    reader2 = PdfReader(prod_folder2 / pdf2)
+    text2 = "\n".join(page.extract_text() or "" for page in reader2.pages)
+    assert "Leveradres" not in text2


### PR DESCRIPTION
## Summary
- Support optional delivery addresses throughout order generation
- Extend CLI and GUI to pass selected delivery address to document writers
- Insert delivery address info into Excel/PDF order headers and add regression tests

## Testing
- `pytest tests/test_defaults_persist.py::test_defaults_persist -q` *(fails: No module named 'pandas')*
- `pip install pandas openpyxl reportlab` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b49a788ebc8322b6967c3eb63a867f