### PR TITLE
Support per-production delivery address maps

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -259,6 +259,11 @@ def cli_copy_per_prod(args):
         if not delivery:
             print("Leveradres niet gevonden")
             return 2
+    prods = set(
+        (str(r.get("Production") or "").strip() or "_Onbekend")
+        for _, r in df.iterrows()
+    )
+    delivery_map = {p: delivery for p in prods}
     cnt, chosen = copy_per_production_and_orders(
         args.source,
         args.dest,
@@ -269,7 +274,7 @@ def cli_copy_per_prod(args):
         {},
         args.remember_defaults,
         client=client,
-        delivery=delivery,
+        delivery_map=delivery_map,
         footer_note=args.note or DEFAULT_FOOTER_NOTE,
     )
     print("Gekopieerd:", cnt)

--- a/gui.py
+++ b/gui.py
@@ -1010,6 +1010,7 @@ def start_gui():
                         self.client_var.get().replace("★ ", "", 1)
                     )
                     delivery = self.delivery_db.get(delivery_id)
+                    delivery_map = {p: delivery for p in prods}
                     cnt, chosen = copy_per_production_and_orders(
                         self.source_folder,
                         self.dest_folder,
@@ -1020,7 +1021,7 @@ def start_gui():
                         doc_map,
                         remember,
                         client=client,
-                        delivery=delivery,
+                        delivery_map=delivery_map,
                         footer_note=DEFAULT_FOOTER_NOTE,
                         zip_parts=bool(self.zip_var.get()),
                     )

--- a/orders.py
+++ b/orders.py
@@ -374,7 +374,7 @@ def copy_per_production_and_orders(
     doc_type_map: Dict[str, str] | None,
     remember_defaults: bool,
     client: Client | None = None,
-    delivery: DeliveryAddress | None = None,
+    delivery_map: Dict[str, DeliveryAddress | None] | None = None,
     footer_note: str = "",
     zip_parts: bool = False,
 ) -> Tuple[int, Dict[str, str]]:
@@ -453,6 +453,7 @@ def copy_per_production_and_orders(
         if supplier.supplier:
             doc_type = doc_type_map.get(prod, "Bestelbon")
             excel_path = os.path.join(prod_folder, f"{doc_type}_{prod}_{today}.xlsx")
+            delivery = delivery_map.get(prod) if delivery_map else None
             write_order_excel(excel_path, items, company, supplier, delivery)
 
             pdf_path = os.path.join(prod_folder, f"{doc_type}_{prod}_{today}.pdf")

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -82,7 +82,7 @@ def run_tests() -> int:
             {},
             True,
             client=client,
-            delivery=None,
+            delivery_map={"Laser": None},
             footer_note=DEFAULT_FOOTER_NOTE,
         )
         assert cnt == 2

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -42,7 +42,7 @@ def test_defaults_persist(tmp_path, monkeypatch):
         {},
         True,
         client=None,
-        delivery=None,
+        delivery_map={"Laser": None, "Plasma": None},
     )
 
     assert cnt == 2

--- a/tests/test_delivery_address_output.py
+++ b/tests/test_delivery_address_output.py
@@ -40,7 +40,7 @@ def test_delivery_address_present_absent(tmp_path):
         {},
         False,
         client=None,
-        delivery=delivery,
+        delivery_map={"Laser": delivery},
     )
     prod_folder = dst1 / "Laser"
     xlsx = next(f for f in os.listdir(prod_folder) if f.endswith(".xlsx"))
@@ -70,7 +70,7 @@ def test_delivery_address_present_absent(tmp_path):
         {},
         False,
         client=None,
-        delivery=None,
+        delivery_map={"Laser": None},
     )
     prod_folder2 = dst2 / "Laser"
     xlsx2 = next(f for f in os.listdir(prod_folder2) if f.endswith(".xlsx"))


### PR DESCRIPTION
## Summary
- allow providing a delivery address map per production when generating order documents
- update CLI, GUI, and tests to supply a per-production delivery map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas openpyxl reportlab -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b4a1f5f7888322a8c59df7b7ad9264