### PR TITLE
Add delivery map and CLI special token tests

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -262,8 +262,15 @@ def cli_copy_per_prod(args):
             prod, name = kv.split("=", 1)
             addr = ddb.get(name)
             if not addr:
-                print("Leveradres niet gevonden")
-                return 2
+                special = [
+                    "Bestelling wordt opgehaald",
+                    "Leveradres wordt nog meegedeeld",
+                ]
+                if name in special:
+                    addr = DeliveryAddress(name=name)
+                else:
+                    print("Leveradres niet gevonden")
+                    return 2
             delivery_map[prod] = addr
     cnt, chosen = copy_per_production_and_orders(
         args.source,

--- a/tests/test_cli_delivery_parsing.py
+++ b/tests/test_cli_delivery_parsing.py
@@ -48,3 +48,53 @@ def test_cli_delivery_parsing(monkeypatch, tmp_path):
     assert set(captured["delivery_map"]) == {"Laser", "Plasma"}
     assert captured["delivery_map"]["Laser"].name == "Addr1"
     assert captured["delivery_map"]["Plasma"].name == "Addr2"
+
+
+def test_cli_delivery_special_tokens(monkeypatch, tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "copy-per-prod",
+        "--source",
+        str(tmp_path / "src"),
+        "--dest",
+        str(tmp_path / "dst"),
+        "--bom",
+        str(tmp_path / "bom.xlsx"),
+        "--exts",
+        "pdf",
+        "--delivery",
+        "Laser=Bestelling wordt opgehaald",
+        "--delivery",
+        "Plasma=Leveradres wordt nog meegedeeld",
+    ])
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "dst").mkdir()
+    df = pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}
+    ])
+    monkeypatch.setattr(cli, "load_bom", lambda path: df)
+
+    sdb = SuppliersDB([Supplier.from_any({"supplier": "ACME"})])
+    monkeypatch.setattr(SuppliersDB, "load", classmethod(lambda cls, path: sdb))
+    cdb = ClientsDB([])
+    monkeypatch.setattr(ClientsDB, "load", classmethod(lambda cls, path: cdb))
+    ddb = DeliveryAddressesDB([])
+    monkeypatch.setattr(DeliveryAddressesDB, "load", classmethod(lambda cls, path: ddb))
+
+    captured = {}
+
+    def fake_copy(*args, **kwargs):
+        captured.update(kwargs)
+        return 0, {}
+
+    monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
+    cli_copy_per_prod(args)
+    assert set(captured["delivery_map"]) == {"Laser", "Plasma"}
+    assert (
+        captured["delivery_map"]["Laser"].name == "Bestelling wordt opgehaald"
+    )
+    assert (
+        captured["delivery_map"]["Plasma"].name
+        == "Leveradres wordt nog meegedeeld"
+    )


### PR DESCRIPTION
## Summary
- Support special delivery tokens (`Bestelling wordt opgehaald`, `Leveradres wordt nog meegedeeld`) in the CLI
- Expand delivery address tests to cover per-production options and special tokens
- Add CLI tests for multiple `--delivery` arguments and special tokens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b4a87a0b2083229399ab9c945b02d1