### PR TITLE
Ensure delivery address placeholder is shown in PDF header

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -147,12 +147,11 @@ def generate_pdf_order_platypus(
 
     right_lines: List[str] = []
     if delivery:
-        dl = [f"<b>Leveradres:</b> {delivery.name}"]
+        right_lines.append(f"<b>Leveradres:</b> {delivery.name}")
         if delivery.address:
-            dl.append(delivery.address)
+            right_lines.extend(delivery.address.splitlines())
         if delivery.remarks:
-            dl.append(delivery.remarks)
-        right_lines = dl
+            right_lines.append(delivery.remarks)
 
     story = []
     story.append(Paragraph(f"{doc_type} productie: {production}", title_style))


### PR DESCRIPTION
## Summary
- Build PDF header right column solely from delivery address and remarks
- Always print delivery block even for placeholder addresses like "Bestelling wordt opgehaald"
- Add regression test for placeholder delivery address

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b4a8628b1083229b9f0504eacc483e