### PR TITLE
Support special delivery address tokens

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -260,11 +260,25 @@ def cli_copy_per_prod(args):
                 print("Leveradres optie moet PROD=NAAM zijn")
                 return 2
             prod, name = kv.split("=", 1)
-            addr = ddb.get(name)
-            if not addr:
-                print("Leveradres niet gevonden")
-                return 2
-            delivery_map[prod] = addr
+            prod = prod.strip()
+            name = name.strip()
+            lname = name.lower()
+            if lname == "none":
+                delivery_map[prod] = None
+            elif lname == "pickup":
+                delivery_map[prod] = DeliveryAddress(
+                    name="Bestelling wordt opgehaald"
+                )
+            elif lname == "tbd":
+                delivery_map[prod] = DeliveryAddress(
+                    name="Leveradres wordt nog meegedeeld"
+                )
+            else:
+                addr = ddb.get(name)
+                if not addr:
+                    print("Leveradres niet gevonden")
+                    return 2
+                delivery_map[prod] = addr
     cnt, chosen = copy_per_production_and_orders(
         args.source,
         args.dest,
@@ -366,7 +380,11 @@ def build_parser() -> argparse.ArgumentParser:
     cpp.add_argument(
         "--delivery",
         action="append",
-        help="Leveradres voor productie: PROD=NAAM (meerdere keren mogelijk)",
+        metavar="PROD=NAME",
+        help=(
+            "Leveradres voor productie: PROD=NAAM. Speciale waarden: "
+            "none, pickup, tbd (meerdere keren mogelijk)"
+        ),
     )
 
     return p

--- a/tests/test_cli_delivery_parsing.py
+++ b/tests/test_cli_delivery_parsing.py
@@ -48,3 +48,55 @@ def test_cli_delivery_parsing(monkeypatch, tmp_path):
     assert set(captured["delivery_map"]) == {"Laser", "Plasma"}
     assert captured["delivery_map"]["Laser"].name == "Addr1"
     assert captured["delivery_map"]["Plasma"].name == "Addr2"
+
+
+def test_cli_delivery_special_tokens(monkeypatch, tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "copy-per-prod",
+        "--source",
+        str(tmp_path / "src"),
+        "--dest",
+        str(tmp_path / "dst"),
+        "--bom",
+        str(tmp_path / "bom.xlsx"),
+        "--exts",
+        "pdf",
+        "--delivery",
+        "Laser=pickup",
+        "--delivery",
+        "Plasma=tbd",
+        "--delivery",
+        "Waterjet=none",
+    ])
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "dst").mkdir()
+    df = pd.DataFrame([
+        {
+            "PartNumber": "PN1",
+            "Description": "",
+            "Production": "Laser",
+            "Aantal": 1,
+        }
+    ])
+    monkeypatch.setattr(cli, "load_bom", lambda path: df)
+
+    sdb = SuppliersDB([Supplier.from_any({"supplier": "ACME"})])
+    monkeypatch.setattr(SuppliersDB, "load", classmethod(lambda cls, path: sdb))
+    cdb = ClientsDB([])
+    monkeypatch.setattr(ClientsDB, "load", classmethod(lambda cls, path: cdb))
+    ddb = DeliveryAddressesDB([])
+    monkeypatch.setattr(DeliveryAddressesDB, "load", classmethod(lambda cls, path: ddb))
+
+    captured = {}
+
+    def fake_copy(*args, **kwargs):
+        captured.update(kwargs)
+        return 0, {}
+
+    monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
+    cli_copy_per_prod(args)
+    assert captured["delivery_map"]["Laser"].name == "Bestelling wordt opgehaald"
+    assert captured["delivery_map"]["Plasma"].name == "Leveradres wordt nog meegedeeld"
+    assert captured["delivery_map"]["Waterjet"] is None


### PR DESCRIPTION
## Summary
- Allow passing `--delivery PROD=NAME` multiple times
- Support `none`, `pickup`, and `tbd` delivery overrides in `cli_copy_per_prod`
- Test delivery parsing including special tokens

## Testing
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest tests/test_cli_delivery_parsing.py::test_cli_delivery_special_tokens -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b4a83f177483228cbe29fbbf4d668c