### PR TITLE
Format delivery address layout in order documents

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -147,7 +147,9 @@ def generate_pdf_order_platypus(
 
     right_lines: List[str] = []
     if delivery:
-        right_lines.append(f"<b>Leveradres:</b> {delivery.name}")
+        # Delivery address block with each piece of information on its own line
+        right_lines.append("<b>Leveradres:</b>")
+        right_lines.append(delivery.name)
         if delivery.address:
             right_lines.extend(delivery.address.splitlines())
         if delivery.remarks:
@@ -320,7 +322,8 @@ def write_order_excel(
     if delivery:
         header_lines.extend(
             [
-                ("Leveradres", delivery.name),
+                ("Leveradres", ""),
+                ("", delivery.name),
                 ("Adres", delivery.address or ""),
                 ("Opmerking", delivery.remarks or ""),
                 ("", ""),

--- a/tests/test_delivery_address_output.py
+++ b/tests/test_delivery_address_output.py
@@ -49,13 +49,15 @@ def test_delivery_address_present_absent(tmp_path):
     col_a = [ws[f"A{i}"].value for i in range(1, 20)]
     assert "Leveradres" in col_a
     row = col_a.index("Leveradres") + 1
-    assert ws[f"B{row}"].value == "Magazijn"
-    assert ws[f"B{row+1}"].value == "Straat 1"
-    assert ws[f"B{row+2}"].value == "achterdeur"
+    # Name is on the next line with an empty label
+    assert ws[f"B{row}"].value in (None, "")
+    assert ws[f"B{row+1}"].value == "Magazijn"
+    assert ws[f"B{row+2}"].value == "Straat 1"
+    assert ws[f"B{row+3}"].value == "achterdeur"
     pdf = next(f for f in os.listdir(prod_folder) if f.endswith(".pdf"))
     reader = PdfReader(prod_folder / pdf)
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
-    assert "Leveradres: Magazijn" in text
+    assert "Leveradres:\nMagazijn" in text
 
     # Without delivery address
     dst2 = tmp_path / "dst2"
@@ -121,11 +123,12 @@ def test_delivery_address_per_production(tmp_path):
     ws1 = wb1.active
     col_a1 = [ws1[f"A{i}"].value for i in range(1, 20)]
     row1 = col_a1.index("Leveradres") + 1
-    assert ws1[f"B{row1}"].value == "Magazijn"
+    assert ws1[f"B{row1}"].value in (None, "")
+    assert ws1[f"B{row1+1}"].value == "Magazijn"
     pdf1 = next(f for f in os.listdir(laser) if f.endswith(".pdf"))
     reader1 = PdfReader(laser / pdf1)
     text1 = "\n".join(page.extract_text() or "" for page in reader1.pages)
-    assert "Leveradres: Magazijn" in text1
+    assert "Leveradres:\nMagazijn" in text1
 
     # Plasma folder checks
     plasma = dst / "Plasma"
@@ -134,11 +137,12 @@ def test_delivery_address_per_production(tmp_path):
     ws2 = wb2.active
     col_a2 = [ws2[f"A{i}"].value for i in range(1, 20)]
     row2 = col_a2.index("Leveradres") + 1
-    assert ws2[f"B{row2}"].value == "Depot"
+    assert ws2[f"B{row2}"].value in (None, "")
+    assert ws2[f"B{row2+1}"].value == "Depot"
     pdf2 = next(f for f in os.listdir(plasma) if f.endswith(".pdf"))
     reader2 = PdfReader(plasma / pdf2)
     text2 = "\n".join(page.extract_text() or "" for page in reader2.pages)
-    assert "Leveradres: Depot" in text2
+    assert "Leveradres:\nDepot" in text2
 
 
 def test_delivery_address_placeholder_prints(tmp_path):


### PR DESCRIPTION
## Summary
- Render delivery address in PDF with each element on its own line
- Expand Excel export to list delivery address name, address, and remarks on separate rows
- Adjust delivery address tests for new multi-line formatting

## Testing
- `pytest tests/test_delivery_address_output.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b4af1580c08322b1030a4570339a15