### PR TITLE
Add CLI options for document type and number

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -279,6 +279,22 @@ def cli_copy_per_prod(args):
                     print("Leveradres niet gevonden")
                     return 2
                 delivery_map[prod] = addr
+    doc_type_map = {}
+    if args.doc_type:
+        for kv in args.doc_type:
+            if "=" not in kv:
+                print("Documenttype optie moet PROD=TYPE zijn")
+                return 2
+            prod, dtyp = kv.split("=", 1)
+            doc_type_map[prod.strip()] = dtyp.strip()
+    doc_num_map = {}
+    if args.doc_number:
+        for kv in args.doc_number:
+            if "=" not in kv:
+                print("Documentnummer optie moet PROD=NUM zijn")
+                return 2
+            prod, num = kv.split("=", 1)
+            doc_num_map[prod.strip()] = num.strip()
     cnt, chosen = copy_per_production_and_orders(
         args.source,
         args.dest,
@@ -286,8 +302,8 @@ def cli_copy_per_prod(args):
         exts,
         db,
         override_map,
-        {},
-        {},
+        doc_type_map,
+        doc_num_map,
         args.remember_defaults,
         client=client,
         delivery_map=delivery_map,
@@ -387,6 +403,19 @@ def build_parser() -> argparse.ArgumentParser:
             "none, pickup, tbd (meerdere keren mogelijk)"
         ),
     )
+    cpp.add_argument(
+        "--doc-type",
+        action="append",
+        metavar="PROD=TYPE",
+        help="Documenttype per productie (meerdere keren mogelijk)",
+    )
+    cpp.add_argument(
+        "--doc-number",
+        action="append",
+        metavar="PROD=NUM",
+        help="Documentnummer per productie (meerdere keren mogelijk)",
+    )
+
 
     return p
 

--- a/tests/test_cli_doc_options.py
+++ b/tests/test_cli_doc_options.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from models import Supplier
+from suppliers_db import SuppliersDB
+from clients_db import ClientsDB
+from delivery_addresses_db import DeliveryAddressesDB
+import cli
+from cli import build_parser, cli_copy_per_prod
+
+
+def test_cli_doc_options_parsing(monkeypatch, tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "copy-per-prod",
+        "--source", str(tmp_path / "src"),
+        "--dest", str(tmp_path / "dst"),
+        "--bom", str(tmp_path / "bom.xlsx"),
+        "--exts", "pdf",
+        "--doc-type", "Laser=Offerteaanvraag",
+        "--doc-number", "Laser=123",
+        "--doc-number", "Plasma=456",
+    ])
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "dst").mkdir()
+    df = pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}
+    ])
+    monkeypatch.setattr(cli, "load_bom", lambda path: df)
+
+    sdb = SuppliersDB([Supplier.from_any({"supplier": "ACME"})])
+    monkeypatch.setattr(SuppliersDB, "load", classmethod(lambda cls, path: sdb))
+    cdb = ClientsDB([])
+    monkeypatch.setattr(ClientsDB, "load", classmethod(lambda cls, path: cdb))
+    ddb = DeliveryAddressesDB([])
+    monkeypatch.setattr(DeliveryAddressesDB, "load", classmethod(lambda cls, path: ddb))
+
+    captured = {}
+
+    def fake_copy(*args, **kwargs):
+        captured.update(kwargs)
+        return 0, {}
+
+    monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
+    cli_copy_per_prod(args)
+
+    assert captured["doc_type_map"] == {"Laser": "Offerteaanvraag"}
+    assert captured["doc_num_map"] == {"Laser": "123", "Plasma": "456"}


### PR DESCRIPTION
## Summary
- add `--doc-type` and `--doc-number` options to the `copy-per-prod` command
- parse document type and number overrides in `cli_copy_per_prod`
- pass maps to `copy_per_production_and_orders` and test parsing

## Testing
- `pytest tests/test_cli_doc_options.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b4b2ded3d883228e73d6ecbfd2ae78