### PR TITLE
Handle optional document numbers in order filenames

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -473,8 +473,9 @@ def copy_per_production_and_orders(
         if supplier.supplier:
             doc_type = doc_type_map.get(prod, "Bestelbon")
             doc_num = doc_num_map.get(prod, "")
+            num_part = f"_{doc_num}" if doc_num else ""
             excel_path = os.path.join(
-                prod_folder, f"{doc_type}_{doc_num}_{prod}_{today}.xlsx"
+                prod_folder, f"{doc_type}{num_part}_{prod}_{today}.xlsx"
             )
             delivery = delivery_map.get(prod)
             write_order_excel(
@@ -482,7 +483,7 @@ def copy_per_production_and_orders(
             )
 
             pdf_path = os.path.join(
-                prod_folder, f"{doc_type}_{doc_num}_{prod}_{today}.pdf"
+                prod_folder, f"{doc_type}{num_part}_{prod}_{today}.pdf"
             )
             try:
                 generate_pdf_order_platypus(

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -56,3 +56,45 @@ def test_doc_number_in_name_and_header(tmp_path):
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
     assert "Bestelbon nr. 123" in text
 
+
+def test_missing_doc_number_has_no_double_underscore(tmp_path):
+    reportlab = pytest.importorskip("reportlab")
+
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "PN1.pdf").write_text("dummy")
+    bom_df = pd.DataFrame(
+        [
+            {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}
+        ]
+    )
+    dst = tmp_path / "dst"
+    dst.mkdir()
+
+    copy_per_production_and_orders(
+        str(src),
+        str(dst),
+        bom_df,
+        [".pdf"],
+        db,
+        {},
+        {},
+        {},
+        False,
+        client=None,
+        delivery_map={},
+    )
+
+    prod_folder = dst / "Laser"
+    today = datetime.date.today().strftime("%Y-%m-%d")
+
+    xlsx_path = prod_folder / f"Bestelbon_Laser_{today}.xlsx"
+    assert xlsx_path.exists()
+    assert not (prod_folder / f"Bestelbon__Laser_{today}.xlsx").exists()
+
+    pdf_path = prod_folder / f"Bestelbon_Laser_{today}.pdf"
+    assert pdf_path.exists()
+    assert not (prod_folder / f"Bestelbon__Laser_{today}.pdf").exists()
+


### PR DESCRIPTION
## Summary
- Avoid double underscores in generated order filenames when no document number is present
- Test missing document numbers to ensure filenames omit extra underscore

## Testing
- `pytest tests/test_doc_numbers.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas openpyxl reportlab -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b4b2f7da20832283b53f4907ac2ddd