### PR TITLE
Import prefix helper into GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -18,6 +18,7 @@ from orders import (
     DEFAULT_FOOTER_NOTE,
     combine_pdfs_per_production,
     combine_pdfs_from_source,
+    _prefix_for_doc_type,
 )
 
 def start_gui():


### PR DESCRIPTION
## Summary
- import `_prefix_for_doc_type` into GUI so document-type prefixes are available for GUI features

## Testing
- `python gui.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b4b8c3ea0483229ba51e8e0054dec1