### PR TITLE
Align document info order and phrasing

### DIFF
--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -60,6 +60,7 @@ def test_doc_number_in_name_and_header(tmp_path):
     assert f"Nummer: BB-123" in text
     assert f"Datum: {today}" in text
     assert "BB-123" not in lines[0]
+    assert lines.index(f"Nummer: BB-123") < lines.index(f"Datum: {today}")
 
 
 def test_prefix_helper():
@@ -118,6 +119,7 @@ def test_offerte_prefix_in_output(tmp_path):
     assert f"Nummer: OFF-42" in text
     assert f"Datum: {today}" in text
     assert "OFF-42" not in lines[0]
+    assert lines.index(f"Nummer: OFF-42") < lines.index(f"Datum: {today}")
 
 
 def test_missing_doc_number_omits_prefix_and_header(tmp_path):

--- a/tests/test_project_info_output.py
+++ b/tests/test_project_info_output.py
@@ -59,17 +59,16 @@ def test_project_info_in_documents(tmp_path, monkeypatch):
     assert xlsx_path.exists()
     wb = openpyxl.load_workbook(xlsx_path)
     ws = wb.active
-    col_a = [ws[f"A{i}"].value for i in range(1, 20)]
-    assert "Projectnr." in col_a
-    assert "Projectnaam" in col_a
-    row_num = col_a.index("Projectnr.") + 1
-    row_name = col_a.index("Projectnaam") + 1
-    assert ws[f"B{row_num}"].value == "PRJ123"
-    assert ws[f"B{row_name}"].value == "New Project"
+    assert ws["A1"].value == "Datum"
+    assert ws["B1"].value == today
+    assert ws["A2"].value == "Projectnr."
+    assert ws["B2"].value == "PRJ123"
+    assert ws["A3"].value == "Projectnaam"
+    assert ws["B3"].value == "New Project"
 
     pdf_path = prod_folder / f"Bestelbon_Laser_{today}.pdf"
     assert pdf_path.exists()
     reader = PdfReader(pdf_path)
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
-    assert "Projectnr.: PRJ123" in text
-    assert "Projectnaam: New Project" in text
+    lines = text.splitlines()
+    assert lines.index(f"Datum: {today}") < lines.index("Projectnr.: PRJ123") < lines.index("Projectnaam: New Project")


### PR DESCRIPTION
## Summary
- ensure order headers include Nummer, Datum, Projectnr., and Projectnaam
- drop old "Bestelbon nr."/"Offerteaanvraag nr." text from generated documents
- test ordering of document info in both Excel and PDF outputs

## Testing
- `pytest tests/test_doc_numbers.py tests/test_project_info_output.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b4c33c814c8322ba525fe5ffaa8e58