### PR TITLE
Refactor document header layout

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -129,20 +129,23 @@ def generate_pdf_order_platypus(
     text_style.leading = 13
     small_style = ParagraphStyle("small", parent=text_style, fontSize=8.5, leading=10.5)
 
+    doc_lines: List[str] = []
+    if doc_number:
+        doc_lines.append(f"Nummer: {doc_number}")
+    today = datetime.date.today().strftime("%Y-%m-%d")
+    doc_lines.append(f"Datum: {today}")
+    if project_number:
+        doc_lines.append(f"Projectnummer: {project_number}")
+    if project_name:
+        doc_lines.append(f"Projectnaam: {project_name}")
+    doc_lines.append("")
+
     company_lines = [
         f"<b>{company_info.get('name','')}</b>",
         f"{company_info.get('address','')}",
         f"BTW: {company_info.get('vat','')}",
         f"E-mail: {company_info.get('email','')}",
     ]
-
-    proj_lines: List[str] = []
-    if project_number:
-        proj_lines.append(f"Projectnr.: {project_number}")
-    if project_name:
-        proj_lines.append(f"Projectnaam: {project_name}")
-    if proj_lines:
-        proj_lines.append("")
 
     # Supplier info with full address and contact details
     addr_parts = []
@@ -168,8 +171,7 @@ def generate_pdf_order_platypus(
     if supplier.phone:
         supp_lines.append(f"Tel: {supplier.phone}")
 
-    sep = [] if proj_lines else [""]
-    left_lines = company_lines + proj_lines + sep + supp_lines
+    left_lines = doc_lines + company_lines + [""] + supp_lines
 
     right_lines: List[str] = []
     if delivery:
@@ -183,8 +185,6 @@ def generate_pdf_order_platypus(
 
     story = []
     title = f"{doc_type} productie: {production}"
-    if doc_number:
-        title = f"{doc_type} nr. {doc_number} productie: {production}"
     story.append(Paragraph(title, title_style))
     story.append(Spacer(0, 6))
     header_tbl = LongTable(
@@ -320,14 +320,15 @@ def write_order_excel(
     )
 
     header_lines: List[Tuple[str, str]] = []
+    today = datetime.date.today().strftime("%Y-%m-%d")
     if doc_number:
-        header_lines.extend([(f"{doc_type} nr.", str(doc_number)), ("", "")])
-    if project_number or project_name:
-        if project_number:
-            header_lines.append(("Projectnr.", project_number))
-        if project_name:
-            header_lines.append(("Projectnaam", project_name))
-        header_lines.append(("", ""))
+        header_lines.append(("Nummer", str(doc_number)))
+    header_lines.append(("Datum", today))
+    if project_number:
+        header_lines.append(("Projectnummer", project_number))
+    if project_name:
+        header_lines.append(("Projectnaam", project_name))
+    header_lines.append(("", ""))
     if company_info:
         header_lines.extend(
             [

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import datetime
 
 import pandas as pd
 import openpyxl
@@ -95,15 +96,18 @@ def run_tests() -> int:
         assert xlsx, "Excel bestelbon niet aangemaakt"
         wb = openpyxl.load_workbook(os.path.join(prod_folder, xlsx[0]))
         ws = wb.active
-        assert ws["A1"].value == "Bedrijf" and ws["B1"].value == client.name
-        assert ws["A6"].value == "Leverancier" and ws["B6"].value == "ACME"
-        assert ws["A7"].value == "Adres"
+        today = datetime.date.today().strftime("%Y-%m-%d")
+        assert ws["A1"].value == "Nummer" and ws["B1"].value == "BB-1"
+        assert ws["A2"].value == "Datum" and ws["B2"].value == today
+        assert ws["A4"].value == "Bedrijf" and ws["B4"].value == client.name
+        assert ws["A9"].value == "Leverancier" and ws["B9"].value == "ACME"
+        assert ws["A10"].value == "Adres"
         assert (
-            ws["B7"].value == "Teststraat 1 bus 2, BE-2000 Antwerpen, BE"
+            ws["B10"].value == "Teststraat 1 bus 2, BE-2000 Antwerpen, BE"
         )
-        assert ws["A8"].value == "BTW" and ws["B8"].value == "BE123"
-        assert ws["A9"].value == "E-mail" and ws["B9"].value == "x@y.z"
-        assert ws["A10"].value == "Tel" and ws["B10"].value == "+32 123"
+        assert ws["A11"].value == "BTW" and ws["B11"].value == "BE123"
+        assert ws["A12"].value == "E-mail" and ws["B12"].value == "x@y.z"
+        assert ws["A13"].value == "Tel" and ws["B13"].value == "+32 123"
         pdfs = [f for f in os.listdir(prod_folder) if f.lower().endswith(".pdf")]
         assert pdfs, "PDF bestelbon niet aangemaakt"
     print("All tests passed.")

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -155,10 +155,11 @@ def test_missing_doc_number_omits_prefix_and_header(tmp_path):
     assert xlsx_path.exists()
     wb = openpyxl.load_workbook(xlsx_path)
     ws = wb.active
-    # Without document number the first header line should be the supplier
-    assert ws["A1"].value == "Leverancier"
+    # Without document number the header starts with the date
+    assert ws["A1"].value == "Datum"
+    assert ws["B1"].value == today
     rows = list(ws.iter_rows(min_row=1, max_row=10, max_col=2, values_only=True))
-    assert ("Datum", today) in rows
+    assert all(r[0] != "Nummer" for r in rows)
 
     pdf_path = prod_folder / f"Bestelbon_Laser_{today}.pdf"
     assert pdf_path.exists()

--- a/tests/test_project_info_output.py
+++ b/tests/test_project_info_output.py
@@ -60,9 +60,9 @@ def test_project_info_in_documents(tmp_path, monkeypatch):
     wb = openpyxl.load_workbook(xlsx_path)
     ws = wb.active
     col_a = [ws[f"A{i}"].value for i in range(1, 20)]
-    assert "Projectnr." in col_a
+    assert "Projectnummer" in col_a
     assert "Projectnaam" in col_a
-    row_num = col_a.index("Projectnr.") + 1
+    row_num = col_a.index("Projectnummer") + 1
     row_name = col_a.index("Projectnaam") + 1
     assert ws[f"B{row_num}"].value == "PRJ123"
     assert ws[f"B{row_name}"].value == "New Project"
@@ -71,5 +71,5 @@ def test_project_info_in_documents(tmp_path, monkeypatch):
     assert pdf_path.exists()
     reader = PdfReader(pdf_path)
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
-    assert "Projectnr.: PRJ123" in text
+    assert "Projectnummer: PRJ123" in text
     assert "Projectnaam: New Project" in text


### PR DESCRIPTION
## Summary
- Streamline order Excel headers: show document number, date and optional project details before company info
- Rework PDF generation to match new header structure and keep document number out of the title
- Adjust tests for updated header positions and field names

## Testing
- `pip install pandas openpyxl reportlab pytest` *(failed: Could not connect to proxy)*
- `pytest tests/test_doc_numbers.py::test_doc_number_in_name_and_header -q` *(failed: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b4c32cd2108322ad9ca3e2a5120ef1