### PR TITLE
Improve combo dropdown filtering

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -646,13 +646,19 @@ def start_gui():
             text = combo.get().strip().lower()
             if not hasattr(self, "_base_options"):
                 return
-            if evt.keysym in ("Up","Down","Return","Escape"):
+            if evt.keysym == "Return":
+                s = self._resolve_text_to_supplier(combo.get().strip())
+                if s:
+                    combo.set(self._disp_to_name.get(s.supplier, s.supplier))
+                return
+            if evt.keysym in ("Up","Down","Escape"):
                 return
             if not text:
                 combo["values"] = self._base_options
             else:
-                filtered = [opt for opt in self._base_options if text in opt.lower()]
+                filtered = [opt for opt in self._base_options if opt.lower().startswith(text)]
                 combo["values"] = filtered or self._base_options
+                combo.event_generate("<Down>")
             self._update_preview_for_text(combo.get())
 
         def _resolve_text_to_supplier(self, text: str) -> Optional[Supplier]:


### PR DESCRIPTION
## Summary
- refine combo dropdown filtering to use prefix matches and auto-dropdown display
- handle Enter key by resolving and normalizing selection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_b_68b5790a204083228b2583b3d87d7832