### PR TITLE
Improve combo box filtering for accent-agnostic search

### DIFF
--- a/tests/test_filter_options.py
+++ b/tests/test_filter_options.py
@@ -1,0 +1,36 @@
+import sys
+import types
+
+# Stub external dependencies used during gui import
+sys.modules.setdefault(
+    "pandas",
+    types.SimpleNamespace(
+        read_excel=lambda *a, **k: None,
+        read_csv=lambda *a, **k: None,
+        DataFrame=object,
+    ),
+)
+openpyxl_mod = types.ModuleType("openpyxl")
+openpyxl_styles = types.ModuleType("openpyxl.styles")
+openpyxl_styles.Alignment = object
+openpyxl_mod.styles = openpyxl_styles
+sys.modules.setdefault("openpyxl", openpyxl_mod)
+sys.modules.setdefault("openpyxl.styles", openpyxl_styles)
+
+from gui import _filter_options
+
+
+def test_filter_options_mixed_case_and_tokens():
+    options = ["Café du Monde", "Cafe Mundo", "Another"]
+    # Mixed case filtering
+    assert _filter_options("cAfE", options) == ["Café du Monde", "Cafe Mundo"]
+    # Tokenised filtering
+    assert _filter_options("cafe monde", options) == ["Café du Monde"]
+    # Empty input returns all options
+    assert _filter_options("", options) == options
+
+
+def test_filter_options_diacritics():
+    options = ["Bäckerei", "Über Supplier", "Cafe"]
+    assert _filter_options("backer", options) == ["Bäckerei"]
+    assert _filter_options("uber", options) == ["Über Supplier"]


### PR DESCRIPTION
## Summary
- Normalize option filtering using accent-stripped, case-insensitive token matching
- Add unit tests for mixed-case and diacritic filtering scenarios

## Testing
- `pytest tests/test_filter_options.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b5829395b48322962e9228feb39542