### PR TITLE
Prioritize favorite suppliers in suggestions

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -21,6 +21,29 @@ from orders import (
     _prefix_for_doc_type,
 )
 
+
+def sort_supplier_options(
+    options: List[str],
+    suppliers: List[Supplier],
+    disp_to_name: Dict[str, str],
+) -> List[str]:
+    """Return options sorted with favorites first and then alphabetically.
+
+    Parameters
+    ----------
+    options: list of display strings
+    suppliers: list of Supplier objects from the DB
+    disp_to_name: mapping from display string to supplier name
+    """
+
+    fav_map = {s.supplier.lower(): s.favorite for s in suppliers}
+
+    def sort_key(opt: str):
+        name = disp_to_name.get(opt, opt)
+        return (not fav_map.get(name.lower(), False), name.lower())
+
+    return sorted(options, key=sort_key)
+
 def start_gui():
     import tkinter as tk
     from tkinter import ttk, filedialog, messagebox, simpledialog
@@ -657,6 +680,9 @@ def start_gui():
                 filtered = self._base_options
             else:
                 filtered = [opt for opt in self._base_options if text in opt.lower()]
+                filtered = sort_supplier_options(
+                    filtered, self.db.suppliers, getattr(self, "_disp_to_name", {})
+                )
             combo["values"] = filtered or self._base_options
             if evt.keysym == "Return" and len(filtered) == 1:
                 combo.set(filtered[0])

--- a/tests/test_supplier_ordering.py
+++ b/tests/test_supplier_ordering.py
@@ -1,0 +1,25 @@
+from models import Supplier
+from gui import sort_supplier_options
+
+
+def test_sort_supplier_options_favorites_first():
+    sups = [
+        Supplier.from_any({"supplier": "Fav1", "favorite": True}),
+        Supplier.from_any({"supplier": "Norm", "favorite": False}),
+        Supplier.from_any({"supplier": "Fav2", "favorite": True}),
+    ]
+    disp_to_name = {"★ Fav1": "Fav1", "Norm": "Norm", "★ Fav2": "Fav2"}
+    options = ["Norm", "★ Fav2", "★ Fav1"]
+    sorted_opts = sort_supplier_options(options, sups, disp_to_name)
+    assert sorted_opts == ["★ Fav1", "★ Fav2", "Norm"]
+
+
+def test_sort_supplier_options_uses_db_not_display_prefix():
+    sups = [
+        Supplier.from_any({"supplier": "Fav", "favorite": True}),
+        Supplier.from_any({"supplier": "Other", "favorite": False}),
+    ]
+    disp_to_name = {"Fav": "Fav", "Other": "Other"}
+    options = ["Other", "Fav"]
+    sorted_opts = sort_supplier_options(options, sups, disp_to_name)
+    assert sorted_opts == ["Fav", "Other"]


### PR DESCRIPTION
## Summary
- Add `sort_supplier_options` helper to order supplier names with favorites first
- Use favorite-aware sorting in supplier combobox typing handler
- Cover supplier option ordering with new tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_b_68b582a04d8083229feaa59ac262667a