### PR TITLE
Add pandas and openpyxl dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 PyPDF2
+pandas
+openpyxl


### PR DESCRIPTION
## Summary
- Include pandas and openpyxl in requirements for BOM spreadsheet import

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b58e52b83083228533ad2e0c3eaea3