### PR TITLE
Use prefix match in supplier filter

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -718,14 +718,15 @@ def start_gui():
                 return
             if not text:
                 filtered = self._base_options
+                combo["values"] = self._base_options
             else:
                 filtered = [
-                    opt for opt in self._base_options if text in _norm(opt)
+                    opt for opt in self._base_options if _norm(opt).startswith(text)
                 ]
                 filtered = sort_supplier_options(
                     filtered, self.db.suppliers, getattr(self, "_disp_to_name", {})
                 )
-            combo["values"] = filtered or self._base_options
+                combo["values"] = filtered
             self._populate_cards(filtered, production)
             if evt.keysym == "Return" and len(filtered) == 1:
                 combo.set(filtered[0])


### PR DESCRIPTION
## Summary
- Ensure supplier combobox filtering matches prefixes rather than substrings
- Update combobox values to show either all options or prefix matches accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b5a3de3e2083229b49fc01e2e76353