### PR TITLE
Use black card highlight

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -797,7 +797,8 @@ def start_gui():
                 self.cards_frame.grid_rowconfigure(r, weight=1)
                 card = tk.Frame(
                     self.cards_frame,
-                    highlightbackground="red",
+                    highlightbackground="black",
+                    highlightcolor="black",
                     highlightthickness=2,
                     cursor="hand2",
                 )


### PR DESCRIPTION
## Summary
- Adjust supplier selection cards to use a black highlight border

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68b5a3e1cff083228dca4edec3911f19