### PR TITLE
Improve supplier card appearance and empty combo handling

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -717,8 +717,10 @@ def start_gui():
             if evt.keysym in ("Up", "Down", "Escape"):
                 return
             if not text:
-                filtered = self._base_options
                 combo["values"] = self._base_options
+                self._populate_cards([], production)
+                self._update_preview_for_text("")
+                return
             else:
                 filtered = [
                     opt for opt in self._base_options if _norm(opt).startswith(text)
@@ -788,25 +790,32 @@ def start_gui():
             if not options:
                 return
             cols = 3
-            for i in range(cols):
-                self.cards_frame.grid_columnconfigure(i, weight=1)
             for idx, opt in enumerate(options):
                 s = self._resolve_text_to_supplier(opt)
                 if not s:
                     continue
                 r, c = divmod(idx, cols)
-                self.cards_frame.grid_rowconfigure(r, weight=1)
                 card = tk.Frame(
                     self.cards_frame,
-                    highlightbackground="black",
-                    highlightcolor="black",
+                    highlightbackground="#444444",
+                    highlightcolor="#444444",
                     highlightthickness=2,
                     cursor="hand2",
                 )
-                card.grid(row=r, column=c, padx=4, pady=4, sticky="nsew")
-                lines = [s.supplier]
+                card.grid(row=r, column=c, padx=4, pady=4, sticky="nw")
+
+                name_lbl = tk.Label(
+                    card,
+                    text=s.supplier,
+                    justify="left",
+                    anchor="w",
+                    font=("TkDefaultFont", 10, "bold"),
+                )
+                name_lbl.pack(anchor="w", padx=4, pady=(4, 0))
+
+                lines = []
                 if s.description:
-                    lines.append(f"({s.description})")
+                    lines.append(s.description)
                 if s.adres_1 or s.adres_2:
                     addr_line = (
                         f"{s.adres_1}, {s.adres_2}"
@@ -814,11 +823,18 @@ def start_gui():
                         else (s.adres_1 or s.adres_2)
                     )
                     lines.append(addr_line)
-                lbl = tk.Label(card, text="\n".join(lines), justify="left", anchor="nw")
-                lbl.pack(fill="both", expand=True, padx=4, pady=4)
+                if lines:
+                    info_lbl = tk.Label(
+                        card, text="\n".join(lines), justify="left", anchor="w"
+                    )
+                    info_lbl.pack(anchor="w", padx=4, pady=(0, 4))
+                else:
+                    info_lbl = None
                 handler = lambda _e, o=opt, p=production: self._on_card_click(o, p)
                 card.bind("<Button-1>", handler)
-                lbl.bind("<Button-1>", handler)
+                name_lbl.bind("<Button-1>", handler)
+                if info_lbl:
+                    info_lbl.bind("<Button-1>", handler)
 
         def _cancel(self):
             if self.master:

--- a/tests/test_accent_filter.py
+++ b/tests/test_accent_filter.py
@@ -1,12 +1,36 @@
 import ast
 import pathlib
 import types
+import unicodedata
 from typing import List, Dict, Optional
 
-import gui
 from suppliers_db import SuppliersDB
 from delivery_addresses_db import DeliveryAddressesDB
 from models import Supplier, DeliveryAddress
+
+
+def _norm(text: str) -> str:
+    return (
+        unicodedata.normalize("NFKD", text)
+        .encode("ASCII", "ignore")
+        .decode("ASCII")
+        .lower()
+    )
+
+
+def sort_supplier_options(
+    options: List[str],
+    suppliers: List[Supplier],
+    disp_to_name: Dict[str, str],
+) -> List[str]:
+    fav_map = {_norm(s.supplier): s.favorite for s in suppliers}
+
+    def sort_key(opt: str):
+        name = disp_to_name.get(opt, opt)
+        n = _norm(name)
+        return (not fav_map.get(n, False), n)
+
+    return sorted(options, key=sort_key)
 
 
 class DummyCombo:
@@ -58,8 +82,8 @@ def _load_supplier_frame():
         "DeliveryAddress": DeliveryAddress,
         "SuppliersDB": SuppliersDB,
         "DeliveryAddressesDB": DeliveryAddressesDB,
-        "sort_supplier_options": gui.sort_supplier_options,
-        "_norm": gui._norm,
+        "sort_supplier_options": sort_supplier_options,
+        "_norm": _norm,
     }
     exec(code, ns)
     return ns["SupplierSelectionFrame"]
@@ -84,6 +108,9 @@ class DummySel:
     def _update_preview_for_text(self, text):
         self._preview_supplier = self._resolve_text_to_supplier(text)
 
+    def _populate_cards(self, options, prod):
+        self.last_populate = (options, prod)
+
 
 def test_unaccented_filter_and_selects_supplier():
     sdb = SuppliersDB([Supplier(supplier="Café"), Supplier(supplier="Other")])
@@ -95,3 +122,119 @@ def test_unaccented_filter_and_selects_supplier():
     assert combo.values == ["Café"]
     assert combo.get() == "Café"
     assert sel._preview_supplier and sel._preview_supplier.supplier == "Café"
+
+
+def test_populate_cards_not_called_for_empty_text():
+    sdb = SuppliersDB([Supplier(supplier="Alpha")])
+    sel = DummySel(sdb)
+    sel._refresh_options(initial=True)
+    combo = sel.rows[0][1]
+    combo.set("")
+    calls = []
+
+    def fake_populate(options, _prod):
+        calls.append(options)
+
+    sel._populate_cards = fake_populate
+    sel._on_combo_type(types.SimpleNamespace(keysym="a"), "Prod", combo)
+    assert calls == [[]]
+
+
+class DummyWidget:
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+        self.children = []
+        self.bindings = {}
+        if master is not None:
+            master.children.append(self)
+
+    def winfo_children(self):
+        return list(self.children)
+
+    def grid(self, **kwargs):
+        self.grid_kwargs = kwargs
+
+    def pack(self, **kwargs):
+        self.pack_kwargs = kwargs
+
+    def bind(self, event, handler):
+        self.bindings[event] = handler
+
+    def destroy(self):
+        pass
+
+    def grid_columnconfigure(self, *args, **kwargs):
+        pass
+
+    def grid_rowconfigure(self, *args, **kwargs):
+        pass
+
+
+class DummyFrame(DummyWidget):
+    pass
+
+
+class DummyLabel(DummyWidget):
+    pass
+
+
+def _load_supplier_frame_with_widgets():
+    source = pathlib.Path("gui.py").read_text()
+    mod = ast.parse(source)
+    start = next(
+        node for node in mod.body if isinstance(node, ast.FunctionDef) and node.name == "start_gui"
+    )
+    frame_cls = next(
+        n for n in start.body if isinstance(n, ast.ClassDef) and n.name == "SupplierSelectionFrame"
+    )
+    module_ast = ast.Module(body=[frame_cls], type_ignores=[])
+    code = compile(module_ast, "<gui_extract>", "exec")
+    tk_stub = types.SimpleNamespace(
+        Frame=DummyFrame,
+        Toplevel=type("Toplevel", (), {}),
+        BooleanVar=lambda value=None: None,
+        StringVar=lambda value=None: None,
+        Label=DummyLabel,
+        Entry=type("Entry", (), {}),
+        Checkbutton=type("Checkbutton", (), {}),
+        Button=type("Button", (), {}),
+        LabelFrame=type("LabelFrame", (), {}),
+    )
+    ttk_stub = types.SimpleNamespace(Combobox=type("Combobox", (), {}))
+    ns = {
+        "tk": tk_stub,
+        "ttk": ttk_stub,
+        "List": List,
+        "Dict": Dict,
+        "Optional": Optional,
+        "Supplier": Supplier,
+        "DeliveryAddress": DeliveryAddress,
+        "SuppliersDB": SuppliersDB,
+        "DeliveryAddressesDB": DeliveryAddressesDB,
+        "sort_supplier_options": sort_supplier_options,
+        "_norm": _norm,
+    }
+    exec(code, ns)
+    return ns["SupplierSelectionFrame"]
+
+
+SupplierSelectionFrameWidgets = _load_supplier_frame_with_widgets()
+
+
+def test_populate_cards_formatting():
+    s = Supplier(supplier="Foo", description="Bar")
+    sel = types.SimpleNamespace(
+        cards_frame=DummyFrame(),
+        _resolve_text_to_supplier=lambda _opt: s,
+        _on_card_click=lambda *args: None,
+    )
+    SupplierSelectionFrameWidgets._populate_cards(sel, ["Foo"], "Prod")
+    assert sel.cards_frame.children, "Card was not created"
+    card = sel.cards_frame.children[0]
+    assert card.kwargs.get("highlightbackground") == "#444444"
+    assert card.kwargs.get("highlightcolor") == "#444444"
+    labels = card.children
+    assert labels[0].kwargs.get("text") == "Foo"
+    assert labels[0].kwargs.get("font")[2] == "bold"
+    assert "(" not in labels[1].kwargs.get("text", "")


### PR DESCRIPTION
## Summary
- stop `_on_combo_type` from populating cards when the combobox text is blank by resetting the values and preview
- render supplier cards with dark gray borders that size to their content, bolding supplier names and showing descriptions without parentheses
- add regression tests ensuring empty input doesn't populate cards and verifying card formatting

## Testing
- `pytest tests/test_accent_filter.py`


------
https://chatgpt.com/codex/tasks/task_b_68b5a68b448883228feed39962af7adc