### PR TITLE
Add separator after project data in supplier selection

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -552,6 +552,8 @@ def start_gui():
             self.project_name_var = tk.StringVar()
             tk.Entry(name_row, textvariable=self.project_name_var, width=50).pack(side="left", padx=6)
 
+            ttk.Separator(left, orient="horizontal").pack(fill="x", pady=(0, 6))
+
             tk.Label(left, text="Kies leveranciers per productie", anchor="w").pack(
                 fill="x", pady=(0, 6)
             )


### PR DESCRIPTION
## Summary
- Insert separator after project info so production supplier choices stand out

## Testing
- `pytest`
- `python gui.py`

------
https://chatgpt.com/codex/tasks/task_b_68b6ce948cd08322819b86a71d31f83b