### PR TITLE
Align column headers in SupplierSelectionFrame

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -577,6 +577,7 @@ def start_gui():
                 text="Producttype",
                 width=18,
                 anchor="w",
+                justify="left",
                 background=left.cget("bg"),
             ).pack(side="left")
             tk.Label(
@@ -584,6 +585,7 @@ def start_gui():
                 text="Leverancier",
                 width=50,
                 anchor="w",
+                justify="left",
                 background=left.cget("bg"),
             ).pack(side="left", padx=6)
             tk.Label(
@@ -591,6 +593,7 @@ def start_gui():
                 text="Documenttype",
                 width=18,
                 anchor="w",
+                justify="left",
                 background=left.cget("bg"),
             ).pack(side="left", padx=6)
             tk.Label(
@@ -598,6 +601,7 @@ def start_gui():
                 text="Nr.",
                 width=8,
                 anchor="w",
+                justify="left",
                 background=left.cget("bg"),
             ).pack(side="left", padx=6)
             tk.Label(
@@ -605,6 +609,7 @@ def start_gui():
                 text="Leveradres",
                 width=50,
                 anchor="w",
+                justify="left",
                 background=left.cget("bg"),
             ).pack(side="left", padx=6)
 


### PR DESCRIPTION
## Summary
- Left-align SupplierSelectionFrame column headers using `anchor='w'` and `justify='left'`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6cea066a48322a2a3f15b30829e45