### PR TITLE
Add client CSV import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ python cli.py clients add "Klant BV" \
     --email "info@klant.be"
 ```
 
+### Opdrachtgevers importeren uit CSV
+
+```
+python cli.py clients import-csv clients.csv \
+    --address "Straat 1, 1000 Brussel" \
+    --vat BE987654321 \
+    --email "info@klant.be"
+```
+
+### Opdrachtgevers exporteren naar CSV
+
+```
+python cli.py clients export-csv clients_export.csv
+```
+
 ### Documentnummer prefixen
 
 Bestelbonnen gebruiken doorgaans een nummer dat begint met `BB-`, terwijl


### PR DESCRIPTION
## Summary
- support importing clients from CSV with optional fallback fields
- allow exporting client database to CSV
- document client CSV import/export in README

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b70ace4cfc8322a400dcc4958ac667