### PR TITLE
Support renaming delivery addresses via CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -186,6 +186,27 @@ def cli_clients(args):
     return 2
 
 
+def cli_delivery_addresses(args):
+    db = DeliveryAddressesDB.load(DELIVERY_DB_FILE)
+    if args.action == "rename":
+        addr = db.get(args.old_name)
+        if not addr:
+            print("Niet gevonden")
+            return 2
+        new_addr = DeliveryAddress(
+            name=args.new_name,
+            address=addr.address,
+            remarks=addr.remarks,
+            favorite=addr.favorite,
+        )
+        db.upsert(new_addr, old_name=args.old_name)
+        db.save(DELIVERY_DB_FILE)
+        print("Hernoemd")
+        return 0
+    print("Onbekende actie")
+    return 2
+
+
 def cli_bom_check(args):
     exts = parse_exts(args.exts)
     df = load_bom(args.bom)
@@ -365,6 +386,12 @@ def build_parser() -> argparse.ArgumentParser:
     crp.add_argument("name")
     cfp = csp.add_parser("fav")
     cfp.add_argument("name")
+
+    dp = sub.add_parser("delivery-addresses", help="Beheer leveradressen")
+    ddsp = dp.add_subparsers(dest="action", required=True)
+    rnp = ddsp.add_parser("rename")
+    rnp.add_argument("old_name")
+    rnp.add_argument("new_name")
 
     bp = sub.add_parser("bom", help="BOM acties")
     bsp = bp.add_subparsers(dest="bact", required=True)

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from cli import (
     cli_bom_check,
     cli_copy,
     cli_copy_per_prod,
+    cli_delivery_addresses,
 )
 from gui import start_gui
 
@@ -36,6 +37,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         return cli_suppliers(args)
     if args.cmd == "clients":
         return cli_clients(args)
+    if args.cmd == "delivery-addresses":
+        return cli_delivery_addresses(args)
     if args.cmd == "bom":
         return cli_bom_check(args)
     if args.cmd == "copy":

--- a/tests/test_delivery_address_rename.py
+++ b/tests/test_delivery_address_rename.py
@@ -1,0 +1,34 @@
+from delivery_addresses_db import DeliveryAddressesDB, DELIVERY_DB_FILE
+from models import DeliveryAddress
+from cli import build_parser, cli_delivery_addresses
+
+
+def test_upsert_allows_rename(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    db = DeliveryAddressesDB([
+        DeliveryAddress(name="Old", address="Street 1"),
+    ])
+    db.save()
+    db.upsert(DeliveryAddress(name="New", address="Street 1"), old_name="Old")
+    db.save()
+    db2 = DeliveryAddressesDB.load(DELIVERY_DB_FILE)
+    assert db2.get("Old") is None
+    renamed = db2.get("New")
+    assert renamed is not None
+    assert renamed.address == "Street 1"
+
+
+def test_cli_rename(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    db = DeliveryAddressesDB([
+        DeliveryAddress(name="Old", address="Street 1"),
+    ])
+    db.save()
+    parser = build_parser()
+    args = parser.parse_args(["delivery-addresses", "rename", "Old", "New"])
+    cli_delivery_addresses(args)
+    db2 = DeliveryAddressesDB.load(DELIVERY_DB_FILE)
+    assert db2.get("Old") is None
+    renamed = db2.get("New")
+    assert renamed is not None
+    assert renamed.address == "Street 1"


### PR DESCRIPTION
## Summary
- allow DeliveryAddressesDB.upsert to rename addresses using optional `old_name`
- add `delivery-addresses rename` CLI action and hook it into main
- test delivery address renaming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b70adb945083228bbf58bba689fe84