### PR TITLE
Validate VAT numbers in CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,7 +10,7 @@ from typing import List
 
 import pandas as pd
 
-from helpers import _to_str, _build_file_index, _unique_path
+from helpers import _to_str, _build_file_index, _unique_path, validate_vat
 from models import Supplier, Client, DeliveryAddress
 from suppliers_db import SuppliersDB, SUPPLIERS_DB_FILE
 from clients_db import ClientsDB, CLIENTS_DB_FILE
@@ -72,7 +72,11 @@ def cli_suppliers(args):
         if args.description:
             rec["description"] = args.description
         if args.btw:
-            rec["btw"] = args.btw
+            vat = validate_vat(args.btw)
+            if not vat:
+                print("Ongeldig BTW-nummer")
+                return 2
+            rec["btw"] = vat
         if args.adres_1:
             rec["adres_1"] = args.adres_1
         if args.adres_2:
@@ -164,7 +168,11 @@ def cli_clients(args):
         if args.address:
             rec["address"] = args.address
         if args.vat:
-            rec["vat"] = args.vat
+            vat = validate_vat(args.vat)
+            if not vat:
+                print("Ongeldig BTW-nummer")
+                return 2
+            rec["vat"] = vat
         if args.email:
             rec["email"] = args.email
         c = Client.from_any(rec)

--- a/helpers.py
+++ b/helpers.py
@@ -1,10 +1,29 @@
 from typing import Any, List, Dict
 import os
+import re
 from collections import defaultdict
 
 
 def _to_str(x: Any) -> str:
     return "" if x is None else str(x)
+
+
+_VAT_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{2,12}$")
+
+
+def validate_vat(vat: str) -> str:
+    """Validate and normalize a VAT number.
+
+    Returns the normalized VAT number (uppercase) when the input matches the
+    basic pattern of two letters followed by 2-12 alphanumeric characters.
+    Otherwise an empty string is returned.
+    """
+    v = _to_str(vat).strip().upper()
+    if not _VAT_RE.fullmatch(v):
+        return ""
+    if not any(ch.isdigit() for ch in v[2:]):
+        return ""
+    return v
 
 
 def _num_to_2dec(val: Any) -> str:

--- a/tests/test_vat_validation.py
+++ b/tests/test_vat_validation.py
@@ -1,0 +1,52 @@
+import cli
+from cli import build_parser, cli_suppliers, cli_clients
+from suppliers_db import SuppliersDB
+from clients_db import ClientsDB
+
+
+def test_cli_supplier_add_valid_vat(monkeypatch, capsys):
+    parser = build_parser()
+    args = parser.parse_args(["suppliers", "add", "ACME", "--btw", "BE0123456789"])
+    db = SuppliersDB([])
+    monkeypatch.setattr(SuppliersDB, "load", staticmethod(lambda *a, **kw: db))
+    monkeypatch.setattr(db, "save", lambda *a, **kw: None)
+    rc = cli_suppliers(args)
+    assert rc == 0
+    assert db.suppliers[0].btw == "BE0123456789"
+
+
+def test_cli_supplier_add_invalid_vat(monkeypatch, capsys):
+    parser = build_parser()
+    args = parser.parse_args(["suppliers", "add", "ACME", "--btw", "INVALID"])
+    db = SuppliersDB([])
+    monkeypatch.setattr(SuppliersDB, "load", staticmethod(lambda *a, **kw: db))
+    monkeypatch.setattr(db, "save", lambda *a, **kw: None)
+    rc = cli_suppliers(args)
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "Ongeldig BTW-nummer" in captured.out
+    assert db.suppliers == []
+
+
+def test_cli_client_add_valid_vat(monkeypatch, capsys):
+    parser = build_parser()
+    args = parser.parse_args(["clients", "add", "Foo", "--vat", "BE0123456789"])
+    db = ClientsDB([])
+    monkeypatch.setattr(ClientsDB, "load", staticmethod(lambda *a, **kw: db))
+    monkeypatch.setattr(db, "save", lambda *a, **kw: None)
+    rc = cli_clients(args)
+    assert rc == 0
+    assert db.clients[0].vat == "BE0123456789"
+
+
+def test_cli_client_add_invalid_vat(monkeypatch, capsys):
+    parser = build_parser()
+    args = parser.parse_args(["clients", "add", "Foo", "--vat", "BADVAT"])
+    db = ClientsDB([])
+    monkeypatch.setattr(ClientsDB, "load", staticmethod(lambda *a, **kw: db))
+    monkeypatch.setattr(db, "save", lambda *a, **kw: None)
+    rc = cli_clients(args)
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "Ongeldig BTW-nummer" in captured.out
+    assert db.clients == []


### PR DESCRIPTION
## Summary
- add regex-based VAT number validator helper
- enforce VAT validation in supplier and client CLI commands
- test VAT validation for both valid and invalid inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b70b3dc9d48322a0f23d94d8fc4a74