### PR TITLE
Enable configurable logging and add verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ Filehopper in Python
 
 ## Voorbeelden
 
+### Logging
+
+Standaard logt de applicatie op INFO-niveau. Gebruik `--verbose` om
+debug-berichten te tonen:
+
+```
+python cli.py --verbose suppliers list
+```
+
 ### Leverancier toevoegen
 
 ```

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sys
+import logging
 from typing import List, Optional
 
 from cli import (
@@ -18,6 +19,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
     parser = build_parser()
     args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if getattr(args, "verbose", False) else logging.INFO,
+        format="%(levelname)s:%(message)s",
+        force=True,
+    )
 
     if getattr(args, "run_tests", False):
         from tests.self_test import run_tests

--- a/orders.py
+++ b/orders.py
@@ -11,6 +11,7 @@ import datetime
 import re
 import zipfile
 import io
+import logging
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
@@ -553,7 +554,7 @@ def copy_per_production_and_orders(
                     project_name=project_name,
                 )
             except Exception as e:
-                print(f"[WAARSCHUWING] PDF mislukt voor {prod}: {e}", file=sys.stderr)
+                logging.warning("PDF mislukt voor %s: %s", prod, e)
 
     # Persist any (possibly unchanged) supplier defaults so that callers can rely on
     # the database reflecting the latest state on disk.

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import tempfile
 import datetime
+import logging
 
 import pandas as pd
 import pytest
@@ -16,7 +17,7 @@ from orders import copy_per_production_and_orders, DEFAULT_FOOTER_NOTE
 
 
 def run_tests() -> int:
-    print("Running self-tests...")
+    logging.info("Running self-tests...")
     db = SuppliersDB()
     db.upsert(Supplier.from_any({
         "supplier": "ACME",
@@ -111,7 +112,7 @@ def run_tests() -> int:
         assert ws["A13"].value == "Tel" and ws["B13"].value == "+32 123"
         pdfs = [f for f in os.listdir(prod_folder) if f.lower().endswith(".pdf")]
         assert pdfs, "PDF bestelbon niet aangemaakt"
-    print("All tests passed.")
+    logging.info("All tests passed.")
     return 0
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,25 @@
+import logging
+
+from cli import build_parser, cli_suppliers
+from main import main
+from suppliers_db import SuppliersDB
+
+
+def test_cli_suppliers_logs(monkeypatch, caplog):
+    parser = build_parser()
+    args = parser.parse_args(["suppliers", "list"])
+    monkeypatch.setattr(SuppliersDB, "load", classmethod(lambda cls, path: SuppliersDB([])))
+    with caplog.at_level(logging.INFO):
+        cli_suppliers(args)
+    assert "(geen leveranciers)" in caplog.text
+
+
+def test_verbose_sets_debug_level(monkeypatch):
+    monkeypatch.setattr(SuppliersDB, "load", classmethod(lambda cls, path: SuppliersDB([])))
+    logging.getLogger().handlers.clear()
+    main(["suppliers", "list"])
+    assert logging.getLogger().getEffectiveLevel() == logging.INFO
+    logging.getLogger().handlers.clear()
+    main(["--verbose", "suppliers", "list"])
+    assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+


### PR DESCRIPTION
## Summary
- replace print statements with logging throughout CLI and orders
- configure root logger in main with optional `--verbose` flag
- document logging usage and add tests for logging output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b70b2c54508322ba3351f47cc71598