### PR TITLE
Add cell clearing with refreshed selection highlighting

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1009,6 +1009,8 @@ def start_gui():
                 self.tree.set(item_id, col_name, "")
             self.sel_canvas.delete("sel_rect")
             self._sel_cells.clear()
+            # Ensure any remaining highlights are removed after the tree updates
+            self.after_idle(self._redraw_selection)
 
         def _remember_cell(self, event):
             """Store the last clicked cell for paste operations."""


### PR DESCRIPTION
## Summary
- Bind the Delete key to a new selection-clearing handler in `CustomBOMFrame`
- Clear selected cells, remove highlight rectangles, and refresh selection highlight afterward

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b73627ce0c8322838baf26f461293b