### PR TITLE
Simplify cell selection handling in CustomBOMFrame

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -976,8 +976,7 @@ def start_gui():
                 self.tree.column(col, width=w, anchor=anchor)
             self.tree.pack(fill="both", expand=True, padx=8, pady=8)
             self.tree.tag_configure("paste_target", background="lightblue")
-            self.tree.bind("<Button-1>", self._remember_cell)
-            self.tree.bind("<Button-1>", self._start_select, add=True)
+            self.tree.bind("<Button-1>", self._start_select)
             self.tree.bind("<B1-Motion>", self._update_selection)
             self.tree.bind("<ButtonRelease-1>", self._finalize_selection)
             self.tree.bind("<Control-v>", self._on_paste)
@@ -1010,30 +1009,23 @@ def start_gui():
             self.sel_canvas.delete("sel_rect")
             self._sel_cells.clear()
 
-        def _remember_cell(self, event):
-            """Store the last clicked cell for paste operations."""
+        def _start_select(self, event):
+            """Begin a new selection at the clicked cell."""
             col = self.tree.identify_column(event.x)
             row = self.tree.identify_row(event.y)
             try:
                 col_idx = int(col.lstrip("#")) - 1
+                items = list(self.tree.get_children())
+                row_idx = items.index(row)
             except Exception:
                 self._paste_cell = None
-                return
-            items = list(self.tree.get_children())
-            if row and row in items:
-                row_idx = items.index(row)
-                self._paste_cell = (row_idx, col_idx)
-            else:
-                self._paste_cell = None
-
-        def _start_select(self, event):
-            """Begin a new selection at the clicked cell."""
-            if self._paste_cell is None:
                 self._sel_anchor = None
                 self.sel_canvas.delete("sel_rect")
                 self._sel_cells.clear()
                 return
-            self._sel_anchor = self._paste_cell
+
+            self._paste_cell = (row_idx, col_idx)
+            self._sel_anchor = (row_idx, col_idx)
             self.sel_canvas.delete("sel_rect")
             self._sel_cells.clear()
             self._update_selection(event)


### PR DESCRIPTION
## Summary
- simplify CustomBOMFrame click handling so `<Button-1>` both anchors paste target and begins selection
- remove helper used only for recording click; `start_select` now records the cell and clears previous highlights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b736142abc832284378afa8895ab1a