### PR TITLE
Bind Command-v to paste in CustomBOMFrame

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -980,6 +980,7 @@ def start_gui():
             self.tree.bind("<B1-Motion>", self._update_selection)
             self.tree.bind("<ButtonRelease-1>", self._finalize_selection)
             self.tree.bind("<Control-v>", self._on_paste)
+            self.tree.bind("<Command-v>", self._on_paste)
             self.tree.bind("<Delete>", self._clear_selection)
             self.tree.bind("<Configure>", lambda e: self._redraw_selection())
             for ev in ("<MouseWheel>", "<Button-4>", "<Button-5>", "<Shift-MouseWheel>"):

--- a/tests/test_custom_bom_paste.py
+++ b/tests/test_custom_bom_paste.py
@@ -1,0 +1,23 @@
+import ast
+import pathlib
+
+
+def test_custom_bom_frame_paste_bindings():
+    source = pathlib.Path("gui.py").read_text()
+    mod = ast.parse(source)
+    start = next(
+        node for node in mod.body if isinstance(node, ast.FunctionDef) and node.name == "start_gui"
+    )
+    custom_cls = next(
+        node for node in start.body if isinstance(node, ast.ClassDef) and node.name == "CustomBOMFrame"
+    )
+    init_fn = next(
+        node for node in custom_cls.body if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    events = []
+    for node in ast.walk(init_fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "bind" and node.args and isinstance(node.args[0], ast.Constant):
+                events.append(node.args[0].value)
+    assert "<Control-v>" in events
+    assert "<Command-v>" in events


### PR DESCRIPTION
## Summary
- ensure `CustomBOMFrame` handles macOS paste via Command+V
- test paste bindings for Control+V and Command+V

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7393630008322ae2c83eaff6fe095