### PR TITLE
Handle missing clipboard during paste in CustomBOMFrame

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1087,9 +1087,15 @@ def start_gui():
                 )
 
         def _on_paste(self, _event=None):
+            """Paste clipboard content into the table.
+
+            Pasting may fail if the operating system or environment lacks
+            clipboard support.
+            """
             try:
                 df = pd.read_clipboard(sep=None, engine="python", header=None)
-            except Exception:
+            except Exception as e:
+                messagebox.showerror("Fout", f"Kan niet plakken: {e}")
                 return "break"
 
             items = list(self.tree.get_children())


### PR DESCRIPTION
## Summary
- Show a message box when pasting from the clipboard fails in the custom BOM table
- Document that pasting may fail when the OS or environment lacks clipboard support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b73934edf883228763eaa91ecf7f58