### PR TITLE
Make selection canvas transparent in Custom BOM frame

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -987,7 +987,7 @@ def start_gui():
                 self.tree.bind(ev, lambda e: self.after_idle(self._redraw_selection()))
 
             # Canvas used to draw selection rectangles
-            self.sel_canvas = tk.Canvas(self.tree, highlightthickness=0)
+            self.sel_canvas = tk.Canvas(self.tree, background="", highlightthickness=0)
             self.sel_canvas.place(relx=0, rely=0, relwidth=1, relheight=1)
 
             # Start with one empty row


### PR DESCRIPTION
## Summary
- Set selection canvas in Custom BOM frame to transparent background for overlaying selection rectangles

## Testing
- `pytest -q`
- `xvfb-run python - <<'PY'
import gui
try:
    gui.start_gui()
    print('GUI started')
except Exception as e:
    print('error', e)
PY`

------
https://chatgpt.com/codex/tasks/task_b_68b73ef121708322bba454ba06d8ccc7