### PR TITLE
Handle missing tkinter and log GUI startup errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,9 +29,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             import tkinter  # noqa: F401
             start_gui()
             return 0
-        except Exception:
+        except ModuleNotFoundError:
+            print("tkinter is not available. Install it to use the GUI.")
             parser.print_help()
             return 0
+        except Exception as exc:
+            print(f"Failed to start GUI: {exc}")
+            parser.print_help()
+            return 1
 
     if args.cmd == "suppliers":
         return cli_suppliers(args)


### PR DESCRIPTION
## Summary
- Handle missing `tkinter` via `ModuleNotFoundError` and present a clear message
- Log GUI startup failures with a specific exception handler
- Only show CLI help when no subcommand and GUI launch fails

## Testing
- `python main.py`
- `PYTHONPATH=/tmp/fake_no_tk python main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b741335a8c8322ba9825bb7fb6fdb0