### PR TITLE
Rename program to Filehopper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PythonHopper
+# Filehopper
 Filehopper in Python
 
 ## Voorbeelden

--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-"""Command-line interface helpers for File Hopper."""
+"""Command-line interface helpers for Filehopper."""
 
 import os
 import shutil
@@ -412,7 +412,7 @@ def cli_copy_per_prod(args):
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description="File Hopper dual-mode")
+    p = argparse.ArgumentParser(description="Filehopper dual-mode")
     p.add_argument(
         "--run-tests", action="store_true", help="Run basic self-tests and exit"
     )

--- a/gui.py
+++ b/gui.py
@@ -949,7 +949,7 @@ def start_gui():
                 style.theme_use("aqua")
             else:
                 style.theme_use("clam")
-            self.title("File Hopper – Miami Vice Edition (Dual-mode)")
+            self.title("Filehopper – Miami Vice Edition (Dual-mode)")
             self.minsize(1024, 720)
 
             self.db = SuppliersDB.load(SUPPLIERS_DB_FILE)

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from gui import start_gui
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    """Entry point for the File Hopper application."""
+    """Entry point for the Filehopper application."""
     argv = argv if argv is not None else sys.argv[1:]
     parser = build_parser()
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Summary
- rename the README heading to Filehopper
- update CLI, GUI, and main entry point strings to use the Filehopper name

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c96d80584c8323a1a3e286cf77d321