### PR TITLE
Add optional export date suffix toggle

### DIFF
--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -6,7 +6,7 @@ import datetime
 
 import pandas as pd
 import pytest
-pytest.importorskip("openpyxl")
+openpyxl = pytest.importorskip("openpyxl")
 
 from models import Supplier, Client
 from suppliers_db import SuppliersDB
@@ -111,6 +111,32 @@ def run_tests() -> int:
         assert ws["A13"].value == "Tel" and ws["B13"].value == "+32 123"
         pdfs = [f for f in os.listdir(prod_folder) if f.lower().endswith(".pdf")]
         assert pdfs, "PDF bestelbon niet aangemaakt"
+
+        dst_dates = os.path.join(td, "dst_dates")
+        os.makedirs(dst_dates)
+        cnt_dates, _ = copy_per_production_and_orders(
+            src,
+            dst_dates,
+            ldf,
+            [".pdf", ".stp"],
+            db,
+            {},
+            {},
+            {"Laser": "1"},
+            True,
+            client=client,
+            delivery_map={},
+            footer_note=DEFAULT_FOOTER_NOTE,
+            date_suffix_exports=True,
+        )
+        assert cnt_dates == 2
+        prod_folder_dates = os.path.join(dst_dates, "Laser")
+        assert os.path.exists(
+            os.path.join(prod_folder_dates, f"PN1_{today}.pdf")
+        )
+        assert os.path.exists(
+            os.path.join(prod_folder_dates, f"PN1_{today}.stp")
+        )
     print("All tests passed.")
     return 0
 


### PR DESCRIPTION
## Summary
- add a GUI toggle to include the current date in export filenames and apply it to flat copies
- extend `copy_per_production_and_orders` to optionally append the date to copied files and ZIP members
- cover the new behaviour in the self test suite and ensure openpyxl is imported correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc4f96056c8322bb51d8a686290dfe