### PR TITLE
Add date prefix option to export names

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -438,6 +438,7 @@ def copy_per_production_and_orders(
     delivery_map: Dict[str, DeliveryAddress] | None = None,
     footer_note: str = "",
     zip_parts: bool = False,
+    date_prefix_exports: bool = False,
     date_suffix_exports: bool = False,
     project_number: str | None = None,
     project_name: str | None = None,
@@ -458,8 +459,10 @@ def copy_per_production_and_orders(
     ``PartNumber`` files. Only the generated order Excel/PDF remain unzipped in
     the production folder.
 
-    When ``date_suffix_exports`` is ``True`` the copied export files will have
-    ``YYYY-MM-DD`` appended to their filename before the extension.
+    When ``date_prefix_exports`` is ``True`` the copied export files will have
+    ``YYYYMMDD-`` prepended to the filename. When ``date_suffix_exports`` is
+    ``True`` ``-YYYYMMDD`` will be inserted before the extension. Both options
+    may be combined.
     """
     os.makedirs(dest, exist_ok=True)
     file_index = _build_file_index(source, selected_exts)
@@ -473,14 +476,19 @@ def copy_per_production_and_orders(
         prod = (row.get("Production") or "").strip() or "_Onbekend"
         prod_to_rows[prod].append(row)
 
-    today = datetime.date.today().strftime("%Y-%m-%d")
+    today = datetime.date.today().strftime("%Y%m%d")
     delivery_map = delivery_map or {}
 
     def _export_name(fname: str) -> str:
-        if not date_suffix_exports:
+        if not (date_prefix_exports or date_suffix_exports):
             return fname
         stem, ext = os.path.splitext(fname)
-        return f"{stem}_{today}{ext}"
+        name = stem
+        if date_prefix_exports:
+            name = f"{today}-{name}"
+        if date_suffix_exports:
+            name = f"{name}-{today}"
+        return f"{name}{ext}"
     for prod, rows in prod_to_rows.items():
         prod_folder = os.path.join(dest, prod)
         os.makedirs(prod_folder, exist_ok=True)

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -98,9 +98,10 @@ def run_tests() -> int:
         assert xlsx, "Excel bestelbon niet aangemaakt"
         wb = openpyxl.load_workbook(os.path.join(prod_folder, xlsx[0]))
         ws = wb.active
-        today = datetime.date.today().strftime("%Y-%m-%d")
+        today_display = datetime.date.today().strftime("%Y-%m-%d")
+        today_file = datetime.date.today().strftime("%Y%m%d")
         assert ws["A1"].value == "Nummer" and ws["B1"].value == "BB-1"
-        assert ws["A2"].value == "Datum" and ws["B2"].value == today
+        assert ws["A2"].value == "Datum" and ws["B2"].value == today_display
         assert ws["A4"].value == "Bedrijf" and ws["B4"].value == client.name
         assert ws["A9"].value == "Leverancier" and ws["B9"].value == "ACME"
         assert ws["A10"].value == "Adres"
@@ -142,10 +143,10 @@ def run_tests() -> int:
         assert cnt_dates == 2
         prod_folder_dates = os.path.join(dst_dates, "Laser")
         assert os.path.exists(
-            os.path.join(prod_folder_dates, f"PN1_{today}.pdf")
+            os.path.join(prod_folder_dates, f"PN1-{today_file}.pdf")
         )
         assert os.path.exists(
-            os.path.join(prod_folder_dates, f"PN1_{today}.stp")
+            os.path.join(prod_folder_dates, f"PN1-{today_file}.stp")
         )
     print("All tests passed.")
     return 0

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -42,24 +42,25 @@ def test_doc_number_in_name_and_header(tmp_path):
     )
 
     prod_folder = dst / "Laser"
-    today = datetime.date.today().strftime("%Y-%m-%d")
+    today_display = datetime.date.today().strftime("%Y-%m-%d")
+    today_file = datetime.date.today().strftime("%Y%m%d")
 
-    xlsx_path = prod_folder / f"Bestelbon_BB-123_Laser_{today}.xlsx"
+    xlsx_path = prod_folder / f"Bestelbon_BB-123_Laser_{today_file}.xlsx"
     assert xlsx_path.exists()
     wb = openpyxl.load_workbook(xlsx_path)
     ws = wb.active
     assert ws["A1"].value == "Nummer"
     assert ws["B1"].value == "BB-123"
     assert ws["A2"].value == "Datum"
-    assert ws["B2"].value == today
+    assert ws["B2"].value == today_display
 
-    pdf_path = prod_folder / f"Bestelbon_BB-123_Laser_{today}.pdf"
+    pdf_path = prod_folder / f"Bestelbon_BB-123_Laser_{today_file}.pdf"
     assert pdf_path.exists()
     reader = PdfReader(pdf_path)
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
     lines = text.splitlines()
     assert f"Nummer: BB-123" in text
-    assert f"Datum: {today}" in text
+    assert f"Datum: {today_display}" in text
     assert "BB-123" not in lines[0]
 
 
@@ -100,24 +101,25 @@ def test_offerte_prefix_in_output(tmp_path):
     )
 
     prod_folder = dst / "Laser"
-    today = datetime.date.today().strftime("%Y-%m-%d")
+    today_display = datetime.date.today().strftime("%Y-%m-%d")
+    today_file = datetime.date.today().strftime("%Y%m%d")
 
-    xlsx_path = prod_folder / f"Offerteaanvraag_OFF-42_Laser_{today}.xlsx"
+    xlsx_path = prod_folder / f"Offerteaanvraag_OFF-42_Laser_{today_file}.xlsx"
     assert xlsx_path.exists()
     wb = openpyxl.load_workbook(xlsx_path)
     ws = wb.active
     assert ws["A1"].value == "Nummer"
     assert ws["B1"].value == "OFF-42"
     assert ws["A2"].value == "Datum"
-    assert ws["B2"].value == today
+    assert ws["B2"].value == today_display
 
-    pdf_path = prod_folder / f"Offerteaanvraag_OFF-42_Laser_{today}.pdf"
+    pdf_path = prod_folder / f"Offerteaanvraag_OFF-42_Laser_{today_file}.pdf"
     assert pdf_path.exists()
     reader = PdfReader(pdf_path)
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
     lines = text.splitlines()
     assert f"Nummer: OFF-42" in text
-    assert f"Datum: {today}" in text
+    assert f"Datum: {today_display}" in text
     assert "OFF-42" not in lines[0]
 
 
@@ -150,22 +152,23 @@ def test_missing_doc_number_omits_prefix_and_header(tmp_path):
     )
 
     prod_folder = dst / "Laser"
-    today = datetime.date.today().strftime("%Y-%m-%d")
+    today_display = datetime.date.today().strftime("%Y-%m-%d")
+    today_file = datetime.date.today().strftime("%Y%m%d")
 
-    xlsx_path = prod_folder / f"Bestelbon_Laser_{today}.xlsx"
+    xlsx_path = prod_folder / f"Bestelbon_Laser_{today_file}.xlsx"
     assert xlsx_path.exists()
     wb = openpyxl.load_workbook(xlsx_path)
     ws = wb.active
     # Without document number the header starts with the date
     assert ws["A1"].value == "Datum"
-    assert ws["B1"].value == today
+    assert ws["B1"].value == today_display
     rows = list(ws.iter_rows(min_row=1, max_row=10, max_col=2, values_only=True))
     assert all(r[0] != "Nummer" for r in rows)
 
-    pdf_path = prod_folder / f"Bestelbon_Laser_{today}.pdf"
+    pdf_path = prod_folder / f"Bestelbon_Laser_{today_file}.pdf"
     assert pdf_path.exists()
     reader = PdfReader(pdf_path)
     text = "\n".join(page.extract_text() or "" for page in reader.pages)
     assert "Nummer:" not in text
-    assert f"Datum: {today}" in text
+    assert f"Datum: {today_display}" in text
 

--- a/tests/test_project_info_output.py
+++ b/tests/test_project_info_output.py
@@ -54,9 +54,9 @@ def test_project_info_in_documents(tmp_path, monkeypatch):
     cli_copy_per_prod(args)
 
     prod_folder = dst / "Laser"
-    today = datetime.date.today().strftime("%Y-%m-%d")
+    today_file = datetime.date.today().strftime("%Y%m%d")
 
-    xlsx_path = prod_folder / f"Bestelbon_Laser_{today}.xlsx"
+    xlsx_path = prod_folder / f"Bestelbon_Laser_{today_file}.xlsx"
     assert xlsx_path.exists()
     wb = openpyxl.load_workbook(xlsx_path)
     ws = wb.active
@@ -68,7 +68,7 @@ def test_project_info_in_documents(tmp_path, monkeypatch):
     assert ws[f"B{row_num}"].value == "PRJ123"
     assert ws[f"B{row_name}"].value == "New Project"
 
-    pdf_path = prod_folder / f"Bestelbon_Laser_{today}.pdf"
+    pdf_path = prod_folder / f"Bestelbon_Laser_{today_file}.pdf"
     assert pdf_path.exists()
     reader = PdfReader(pdf_path)
     text = "\n".join(page.extract_text() or "" for page in reader.pages)


### PR DESCRIPTION
## Summary
- add a date_prefix_exports flag to copy_per_production_and_orders and update the export naming logic
- switch generated filenames to compact YYYYMMDD dates and apply the same transformation in zip archives
- adjust regression tests to expect the new filename format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd3c7c573c83229368c7d4c404b403