### PR TITLE
Update export date naming and coverage

### DIFF
--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -98,7 +98,9 @@ def run_tests() -> int:
         assert xlsx, "Excel bestelbon niet aangemaakt"
         wb = openpyxl.load_workbook(os.path.join(prod_folder, xlsx[0]))
         ws = wb.active
-        today = datetime.date.today().strftime("%Y-%m-%d")
+        today_date = datetime.date.today()
+        today = today_date.strftime("%Y-%m-%d")
+        today_stamp = today_date.strftime("%Y%m%d")
         assert ws["A1"].value == "Nummer" and ws["B1"].value == "BB-1"
         assert ws["A2"].value == "Datum" and ws["B2"].value == today
         assert ws["A4"].value == "Bedrijf" and ws["B4"].value == client.name
@@ -142,10 +144,63 @@ def run_tests() -> int:
         assert cnt_dates == 2
         prod_folder_dates = os.path.join(dst_dates, "Laser")
         assert os.path.exists(
-            os.path.join(prod_folder_dates, f"PN1_{today}.pdf")
+            os.path.join(prod_folder_dates, f"PN1-{today_stamp}.pdf")
         )
         assert os.path.exists(
-            os.path.join(prod_folder_dates, f"PN1_{today}.stp")
+            os.path.join(prod_folder_dates, f"PN1-{today_stamp}.stp")
+        )
+
+        dst_prefix = os.path.join(td, "dst_prefix")
+        os.makedirs(dst_prefix)
+        cnt_prefix, _ = copy_per_production_and_orders(
+            src,
+            dst_prefix,
+            ldf,
+            [".pdf", ".stp"],
+            db,
+            {},
+            {},
+            {"Laser": "1"},
+            True,
+            client=client,
+            delivery_map={},
+            footer_note=DEFAULT_FOOTER_NOTE,
+            date_prefix_exports=True,
+        )
+        assert cnt_prefix == 2
+        prod_folder_prefix = os.path.join(dst_prefix, "Laser")
+        assert os.path.exists(
+            os.path.join(prod_folder_prefix, f"{today_stamp}-PN1.pdf")
+        )
+        assert os.path.exists(
+            os.path.join(prod_folder_prefix, f"{today_stamp}-PN1.stp")
+        )
+
+        dst_both = os.path.join(td, "dst_both")
+        os.makedirs(dst_both)
+        cnt_both, _ = copy_per_production_and_orders(
+            src,
+            dst_both,
+            ldf,
+            [".pdf", ".stp"],
+            db,
+            {},
+            {},
+            {"Laser": "1"},
+            True,
+            client=client,
+            delivery_map={},
+            footer_note=DEFAULT_FOOTER_NOTE,
+            date_prefix_exports=True,
+            date_suffix_exports=True,
+        )
+        assert cnt_both == 2
+        prod_folder_both = os.path.join(dst_both, "Laser")
+        assert os.path.exists(
+            os.path.join(prod_folder_both, f"{today_stamp}-PN1-{today_stamp}.pdf")
+        )
+        assert os.path.exists(
+            os.path.join(prod_folder_both, f"{today_stamp}-PN1-{today_stamp}.stp")
         )
     print("All tests passed.")
     return 0


### PR DESCRIPTION
## Summary
- add support for prefixing/suffixing copied export filenames with YYYYMMDD in `copy_per_production_and_orders`
- extend the self-test to validate prefix, suffix and combined date naming patterns

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68cd3c8f67948322b8cd2f5abde5ec66