### PR TITLE
Handle missing tksheet dependency gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Filehopper
 Filehopper in Python
 
+## Installatie
+
+De GUI-componenten gebruiken het externe pakket [`tksheet`](https://github.com/ragardner/tksheet).
+Installeer eerst de basisvereisten en daarna `tksheet`:
+
+```bash
+pip install -r requirements.txt
+pip install tksheet
+```
+
+Start vervolgens de applicatie met `python main.py` of `python -m gui`.
+
 ## Voorbeelden
 
 ### Leverancier toevoegen

--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -63,7 +63,37 @@ from typing import Callable, Iterable, List, Optional, Sequence, Tuple
 import tkinter as tk
 from tkinter import messagebox, ttk
 
-import tksheet
+try:
+    import tksheet
+    _TKSHEET_IMPORT_ERROR: Optional[BaseException] = None
+except ModuleNotFoundError as exc:  # pragma: no cover - afhankelijk van installatie
+    tksheet = None  # type: ignore[assignment]
+    _TKSHEET_IMPORT_ERROR = exc
+
+_TKSHEET_ERROR = (
+    "De module 'tksheet' is niet geïnstalleerd. "
+    "Voer 'pip install tksheet' uit voordat u de Filehopper GUI start."
+)
+
+
+def _ensure_tksheet_available() -> None:
+    if tksheet is not None:
+        return
+
+    try:
+        import tkinter as _tk
+        from tkinter import messagebox as _messagebox
+
+        _root = _tk.Tk()
+        _root.withdraw()
+        try:
+            _messagebox.showerror("tksheet ontbreekt", _TKSHEET_ERROR)
+        finally:
+            _root.destroy()
+    except Exception:
+        # Val stilletjes terug op een consolefout wanneer Tkinter niet beschikbaar is
+        pass
+    raise RuntimeError(_TKSHEET_ERROR) from _TKSHEET_IMPORT_ERROR
 
 
 CellCoord = Tuple[int, int]
@@ -102,6 +132,8 @@ class BOMCustomTab(ttk.Frame):
         event_target: Optional[tk.Misc] = None,
         max_undo: int = 50,
     ) -> None:
+        _ensure_tksheet_available()
+
         super().__init__(master)
         self.app_name = app_name
         self.on_custom_bom_ready = on_custom_bom_ready

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from cli import (
     cli_copy_per_prod,
     cli_delivery_addresses,
 )
-from gui import start_gui
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -27,11 +26,22 @@ def main(argv: Optional[List[str]] = None) -> int:
     if not getattr(args, "cmd", None):
         try:
             import tkinter  # noqa: F401
-            start_gui()
-            return 0
         except Exception:
             parser.print_help()
             return 0
+
+        try:
+            from gui import start_gui
+        except RuntimeError as exc:
+            print(exc, file=sys.stderr)
+            return 1
+
+        try:
+            start_gui()
+        except RuntimeError as exc:
+            print(exc, file=sys.stderr)
+            return 1
+        return 0
 
     if args.cmd == "suppliers":
         return cli_suppliers(args)


### PR DESCRIPTION
## Summary
- ensure BOMCustomTab checks for tksheet and shows a clear installation hint when the dependency is missing
- surface RuntimeError messages when launching the GUI so users see missing dependency hints
- document the need to install tksheet before starting the GUI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ce8cfd1e8c8322ae5038d9e1ff9168