### PR TITLE
Enable tksheet native scrollbars

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -174,8 +174,6 @@ class BOMCustomTab(ttk.Frame):
             container,
             headers=self.HEADERS,
             show_index=False,
-            show_x_scrollbar=False,
-            show_y_scrollbar=False,
         )
         self.sheet.enable_bindings(
             (
@@ -188,12 +186,6 @@ class BOMCustomTab(ttk.Frame):
         )
         self.sheet.set_sheet_data([])
         self.sheet.grid(row=0, column=0, sticky="nsew")
-
-        vsb = ttk.Scrollbar(container, orient="vertical", command=self.sheet.yview)
-        hsb = ttk.Scrollbar(container, orient="horizontal", command=self.sheet.xview)
-        self.sheet.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
-        vsb.grid(row=0, column=1, sticky="ns")
-        hsb.grid(row=1, column=0, sticky="ew")
 
         self.sheet.bind("<Control-v>", self._on_paste)
         self.sheet.bind("<Control-V>", self._on_paste)


### PR DESCRIPTION
## Summary
- allow the BOM custom sheet widget to manage its own scrollbars instead of wrapping it in ttk scrollbars

## Testing
- python main.py *(fails: no display available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ce8f9fec7c8322b7a12fd8ffe71705