### PR TITLE
Update custom BOM headers to new schema

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -34,8 +34,8 @@ wordt door ``Ctrl+Z`` in omgekeerde volgorde verwerkt.
 
 CSV-schema
 ==========
-Er worden acht vaste kolommen geëxporteerd in deze volgorde:
-``PartNumber, Description, Quantity, Unit, Production, Drawing, Finish, Material``.
+Er worden twaalf vaste kolommen geëxporteerd in deze volgorde:
+``PartNumber, Description, QTY., Profile, Length profile, Thickness, Production, Material, Finish, RAL color, Weight (kg), Surface Area (m²)``.
 Velden worden met een komma gescheiden en automatisch gequote door ``csv.writer``.
 
 Notebook-integratie
@@ -115,12 +115,16 @@ class BOMCustomTab(ttk.Frame):
     HEADERS: Tuple[str, ...] = (
         "PartNumber",
         "Description",
-        "Quantity",
-        "Unit",
+        "QTY.",
+        "Profile",
+        "Length profile",
+        "Thickness",
         "Production",
-        "Drawing",
-        "Finish",
         "Material",
+        "Finish",
+        "RAL color",
+        "Weight (kg)",
+        "Surface Area (m²)",
     )
 
     def __init__(


### PR DESCRIPTION
## Summary
- update the CSV schema documentation of the custom BOM tab to list the twelve required columns
- replace `BOMCustomTab.HEADERS` with the new column names so the grid and exports share the updated schema

## Testing
- `python -m gui` *(module defines no entry point; GUI not started in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce9601148883228ca62dbb85e8c84c