### PR TITLE
Use set_column_widths for BOM auto-resize

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -272,6 +272,7 @@ class BOMCustomTab(ttk.Frame):
         min_width = 60
         total_rows = self.sheet.get_total_rows()
 
+        widths = {}
         for col in valid_columns:
             max_width = header_font.measure(self.HEADERS[col])
             for row in range(total_rows):
@@ -282,7 +283,10 @@ class BOMCustomTab(ttk.Frame):
                 if cell_width > max_width:
                     max_width = cell_width
             target_width = max(min_width, max_width + padding)
-            self.sheet.set_column_width(col, target_width, redraw=False)
+            widths[col] = target_width
+
+        if widths:
+            self.sheet.set_column_widths(widths, redraw=False)
 
         self.sheet.refresh()
 


### PR DESCRIPTION
## Summary
- build a column width mapping in `_auto_resize_columns`
- call `set_column_widths` once to apply the calculated widths while retaining the final refresh

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ce9fb8e09483229bc13effc9dcd07c