### PR TITLE
Introduce export bundle handling for CLI and GUI

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,7 +1,11 @@
-from typing import Any, List, Dict
+from __future__ import annotations
+
+import datetime
 import os
 import re
 from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
 
 def _to_str(x: Any) -> str:
@@ -74,3 +78,134 @@ def _unique_path(path: str) -> str:
         if not os.path.exists(candidate):
             return candidate
         i += 1
+
+
+@dataclass(slots=True)
+class ExportBundleResult:
+    """Result metadata for :func:`create_export_bundle`."""
+
+    root_dir: str
+    bundle_dir: str
+    folder_name: str
+    dry_run: bool
+    used_fallback: bool
+    warnings: List[str]
+    latest_symlink: str | None = None
+
+
+_INVALID_BUNDLE_CHARS = set('<>:\\"/|?*')
+
+
+def _sanitize_bundle_component(value: object) -> str:
+    """Return a filesystem-friendly representation of ``value``."""
+
+    text = _to_str(value).strip()
+    if not text:
+        return ""
+    # Collapse whitespace and drop control characters
+    text = " ".join(text.split())
+    cleaned = []
+    for ch in text:
+        if ch in _INVALID_BUNDLE_CHARS or ord(ch) < 32:
+            cleaned.append("_")
+            continue
+        if ch == os.sep or (os.altsep and ch == os.altsep):
+            cleaned.append("-")
+            continue
+        cleaned.append(ch)
+    result = "".join(cleaned).strip(" .-_")
+    return result
+
+
+def create_export_bundle(
+    base_dir: str,
+    project_number: str | None,
+    project_name: str | None,
+    *,
+    latest_symlink: bool | str = False,
+    dry_run: bool = False,
+    timestamp: datetime.datetime | None = None,
+) -> ExportBundleResult:
+    """Create or determine an export bundle directory within ``base_dir``.
+
+    The directory name is derived from ``project_number`` and ``project_name``.
+    Missing or unusable values fall back to ``bundle-YYYYMMDD-HHMMSS``. When
+    ``dry_run`` is ``True`` the directory and optional symlink are not created.
+
+    ``latest_symlink`` enables creation of a symlink inside ``base_dir`` that
+    points to the bundle directory. When a string is provided it is used as the
+    symlink name; otherwise ``"latest"`` is used. Existing non-symlink paths
+    with the same name are left untouched and reported via ``warnings``.
+    """
+
+    root_dir = os.path.abspath(base_dir)
+    components: List[str] = []
+    warnings: List[str] = []
+
+    pn = _sanitize_bundle_component(project_number)
+    if pn:
+        components.append(pn)
+    elif _to_str(project_number).strip():
+        warnings.append("Projectnummer bevat geen geldige tekens en is overgeslagen.")
+
+    pname = _sanitize_bundle_component(project_name)
+    if pname:
+        components.append(pname)
+    elif _to_str(project_name).strip():
+        warnings.append("Projectnaam bevat geen geldige tekens en is overgeslagen.")
+
+    used_fallback = False
+    if components:
+        folder_name = " - ".join(components)
+    else:
+        used_fallback = True
+        if not (project_number or project_name):
+            warnings.append(
+                "Projectnummer of -naam ontbreekt; er wordt een fallbackmap gebruikt."
+            )
+        timestamp = timestamp or datetime.datetime.now()
+        folder_name = timestamp.strftime("bundle-%Y%m%d-%H%M%S")
+
+    bundle_dir = os.path.abspath(os.path.join(root_dir, folder_name))
+
+    if not dry_run:
+        os.makedirs(bundle_dir, exist_ok=True)
+
+    latest_path: str | None = None
+    link_requested = bool(latest_symlink)
+    link_name = "latest"
+    if isinstance(latest_symlink, str):
+        custom = _sanitize_bundle_component(latest_symlink)
+        if custom:
+            link_name = custom
+        elif latest_symlink.strip():
+            warnings.append(
+                "Naam voor 'latest'-symlink bevat geen geldige tekens; standaardnaam gebruikt."
+            )
+    if link_requested:
+        latest_path = os.path.abspath(os.path.join(root_dir, link_name))
+        if not dry_run:
+            try:
+                if os.path.lexists(latest_path):
+                    if os.path.islink(latest_path) or not os.path.isdir(latest_path):
+                        os.unlink(latest_path)
+                    else:
+                        warnings.append(
+                            f"Kan symlink '{latest_path}' niet maken: pad bestaat al en is geen symlink."
+                        )
+                        latest_path = None
+                if latest_path is not None:
+                    os.symlink(bundle_dir, latest_path, target_is_directory=True)
+            except (OSError, NotImplementedError) as exc:
+                warnings.append(f"Kon symlink '{latest_path}' niet maken: {exc}")
+                latest_path = None
+
+    return ExportBundleResult(
+        root_dir=root_dir,
+        bundle_dir=bundle_dir,
+        folder_name=folder_name,
+        dry_run=dry_run,
+        used_fallback=used_fallback,
+        warnings=warnings,
+        latest_symlink=latest_path,
+    )

--- a/tests/test_project_info_output.py
+++ b/tests/test_project_info_output.py
@@ -1,4 +1,6 @@
 import datetime
+from pathlib import Path
+
 import pandas as pd
 import pytest
 pytest.importorskip("openpyxl")
@@ -7,6 +9,7 @@ from PyPDF2 import PdfReader
 
 import cli
 from cli import build_parser, cli_copy_per_prod
+from helpers import create_export_bundle
 from models import Supplier
 from suppliers_db import SuppliersDB
 from clients_db import ClientsDB
@@ -53,7 +56,8 @@ def test_project_info_in_documents(tmp_path, monkeypatch):
 
     cli_copy_per_prod(args)
 
-    prod_folder = dst / "Laser"
+    bundle = create_export_bundle(str(dst), "PRJ123", "New Project", dry_run=True)
+    prod_folder = Path(bundle.bundle_dir) / "Laser"
     today = datetime.date.today().strftime("%Y-%m-%d")
 
     xlsx_path = prod_folder / f"Bestelbon_Laser_{today}.xlsx"


### PR DESCRIPTION
## Summary
- add a reusable `create_export_bundle` helper that derives sanitized bundle directories, supports optional `latest` symlinks and dry-run reporting
- call the helper from the CLI before copying so the bundle path is printed and expose switches for the optional behaviours
- update the GUI copy flows to use the helper, surface the bundle directory in notifications, and adjust the project info test to expect the new layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cfe955b19c832293454ad763df51f6