### PR TITLE
Add export bundle helper and update tests

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,6 +1,9 @@
 from typing import Any, List, Dict
+import datetime
+import errno
 import os
 import re
+import shutil
 from collections import defaultdict
 
 
@@ -74,3 +77,103 @@ def _unique_path(path: str) -> str:
         if not os.path.exists(candidate):
             return candidate
         i += 1
+
+
+def _sanitize_bundle_label(label: str | None) -> str:
+    """Return a filesystem friendly label for export bundles."""
+
+    text = _to_str(label).strip()
+    if not text:
+        return ""
+    text = re.sub(r"\s+", " ", text)
+    # Replace all characters that may cause issues on filesystems.
+    sanitized = re.sub(r"[^0-9A-Za-z._-]+", "_", text)
+    sanitized = sanitized.strip("._-")
+    return sanitized
+
+
+def create_export_bundle(
+    root: str,
+    label: str | None = None,
+    *,
+    timestamp: datetime.datetime | None = None,
+    latest_name: str = "latest",
+    max_attempts: int = 50,
+) -> Dict[str, str]:
+    """Create a timestamped export bundle directory inside ``root``.
+
+    Parameters
+    ----------
+    root:
+        Base directory that will contain per-run export bundles.
+    label:
+        Optional descriptor that becomes part of the directory name after
+        sanitising. When empty, only the timestamp will be used.
+    timestamp:
+        Optional datetime used for deterministic naming in tests.
+    latest_name:
+        Name of the symlink that should point to the most recent bundle.
+    max_attempts:
+        Number of attempts when incrementing suffixes for existing bundles.
+
+    Returns
+    -------
+    dict
+        Mapping with ``root``, ``name``, ``path`` and ``latest`` keys.
+    """
+
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+
+    ts = timestamp or datetime.datetime.now()
+    base_root = os.path.abspath(root)
+    os.makedirs(base_root, exist_ok=True)
+
+    label_clean = _sanitize_bundle_label(label)
+    base_name = ts.strftime("%Y%m%d-%H%M%S")
+    if label_clean:
+        base_name = f"{base_name}_{label_clean}"
+
+    attempt = 0
+    bundle_path = ""
+    bundle_name = ""
+    while attempt < max_attempts:
+        suffix = "" if attempt == 0 else f"-{attempt + 1}"
+        candidate_name = f"{base_name}{suffix}"
+        candidate_path = os.path.join(base_root, candidate_name)
+        try:
+            os.makedirs(candidate_path)
+            bundle_path = candidate_path
+            bundle_name = candidate_name
+            break
+        except FileExistsError:
+            attempt += 1
+            continue
+        except OSError as exc:
+            if exc.errno == errno.EEXIST:
+                attempt += 1
+                continue
+            raise
+    else:
+        raise RuntimeError(
+            f"Kon geen exportbundel aanmaken in {base_root} na {max_attempts} pogingen"
+        )
+
+    latest_path = os.path.join(base_root, latest_name)
+    try:
+        if os.path.lexists(latest_path):
+            if os.path.islink(latest_path) or not os.path.isdir(latest_path):
+                os.unlink(latest_path)
+            else:
+                shutil.rmtree(latest_path)
+        os.symlink(bundle_name, latest_path)
+    except OSError:
+        # Symlinks might not be supported; expose that to callers via None.
+        latest_path = None
+
+    return {
+        "root": base_root,
+        "name": bundle_name,
+        "path": bundle_path,
+        "latest": latest_path,
+    }

--- a/tests/test_cli_delivery_parsing.py
+++ b/tests/test_cli_delivery_parsing.py
@@ -41,13 +41,16 @@ def test_cli_delivery_parsing(monkeypatch, tmp_path):
 
     def fake_copy(*args, **kwargs):
         captured.update(kwargs)
-        return 0, {}
+        return 0, {}, kwargs.get("bundle")
 
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)
     assert set(captured["delivery_map"]) == {"Laser", "Plasma"}
     assert captured["delivery_map"]["Laser"].name == "Addr1"
     assert captured["delivery_map"]["Plasma"].name == "Addr2"
+    bundle = captured.get("bundle")
+    assert isinstance(bundle, dict)
+    assert bundle["path"].startswith(str(tmp_path / "dst"))
 
 
 def test_cli_delivery_special_tokens(monkeypatch, tmp_path):
@@ -93,10 +96,13 @@ def test_cli_delivery_special_tokens(monkeypatch, tmp_path):
 
     def fake_copy(*args, **kwargs):
         captured.update(kwargs)
-        return 0, {}
+        return 0, {}, kwargs.get("bundle")
 
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)
     assert captured["delivery_map"]["Laser"].name == "Bestelling wordt opgehaald"
     assert captured["delivery_map"]["Plasma"].name == "Leveradres wordt nog meegedeeld"
     assert captured["delivery_map"]["Waterjet"] is None
+    bundle = captured.get("bundle")
+    assert isinstance(bundle, dict)
+    assert bundle["path"].startswith(str(tmp_path / "dst"))

--- a/tests/test_cli_doc_options.py
+++ b/tests/test_cli_doc_options.py
@@ -38,10 +38,13 @@ def test_cli_doc_options_parsing(monkeypatch, tmp_path):
 
     def fake_copy(*args, **kwargs):
         captured.update(kwargs)
-        return 0, {}
+        return 0, {}, kwargs.get("bundle")
 
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)
 
     assert captured["doc_type_map"] == {"Laser": "Offerteaanvraag"}
     assert captured["doc_num_map"] == {"Laser": "123", "Plasma": "456"}
+    bundle = captured.get("bundle")
+    assert isinstance(bundle, dict)
+    assert bundle["path"].startswith(str(tmp_path / "dst"))

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -1,5 +1,6 @@
 import os
 import pandas as pd
+from helpers import create_export_bundle
 from models import Supplier
 from suppliers_db import SuppliersDB
 from orders import copy_per_production_and_orders
@@ -32,9 +33,10 @@ def test_defaults_persist(tmp_path, monkeypatch):
     overrides = {"Laser": "ACME", "Plasma": "BETA"}
 
     # Run the copy and order generation, remembering defaults
-    cnt, chosen = copy_per_production_and_orders(
+    bundle = create_export_bundle(dst, "Defaults")
+    cnt, chosen, bundle_info = copy_per_production_and_orders(
         str(src),
-        str(dst),
+        str(bundle["path"]),
         bom_df,
         [".pdf"],
         db,
@@ -44,10 +46,13 @@ def test_defaults_persist(tmp_path, monkeypatch):
         True,
         client=None,
         delivery_map={},
+        bundle=bundle,
     )
 
     assert cnt == 2
     assert chosen == overrides
+    if bundle_info.get("latest"):
+        assert (tmp_path / "dst" / "latest").is_symlink()
 
     # Defaults should be updated in memory
     assert db.defaults_by_production == overrides

--- a/tests/test_export_bundle.py
+++ b/tests/test_export_bundle.py
@@ -1,0 +1,101 @@
+import datetime
+import os
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from helpers import create_export_bundle
+from models import Supplier
+from orders import copy_per_production_and_orders
+from suppliers_db import SuppliersDB
+
+
+def test_create_export_bundle_formats_and_sanitises(tmp_path):
+    ts = datetime.datetime(2023, 1, 2, 3, 4, 5)
+    bundle = create_export_bundle(
+        tmp_path,
+        "Client: Demo/Project",
+        timestamp=ts,
+    )
+    expected_name = "20230102-030405_Client_Demo_Project"
+    assert bundle["name"] == expected_name
+    assert Path(bundle["path"]).is_dir()
+    latest = tmp_path / "latest"
+    assert latest.is_symlink()
+    assert os.readlink(latest) == expected_name
+
+
+def test_create_export_bundle_suffix_and_limits(tmp_path):
+    ts = datetime.datetime(2023, 6, 1, 12, 0, 0)
+    first = create_export_bundle(tmp_path, "Project", timestamp=ts)
+    assert first["name"].endswith("_Project")
+    second = create_export_bundle(tmp_path, "Project", timestamp=ts)
+    assert second["name"].endswith("_Project-2")
+
+    # Force the helper to exhaust attempts
+    third_root = tmp_path / "other"
+    third_root.mkdir()
+    conflict_name = ts.strftime("%Y%m%d-%H%M%S")
+    (third_root / conflict_name).mkdir()
+    with pytest.raises(RuntimeError):
+        create_export_bundle(third_root, "", timestamp=ts, max_attempts=1)
+
+
+def test_create_export_bundle_permission_error(tmp_path, monkeypatch):
+    root = tmp_path / "locked"
+    root.mkdir()
+
+    original_makedirs = os.makedirs
+
+    def fake_makedirs(path, *args, **kwargs):
+        if os.path.abspath(path) != os.path.abspath(root):
+            raise PermissionError("no write access")
+        return original_makedirs(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "makedirs", fake_makedirs)
+
+    with pytest.raises(PermissionError):
+        create_export_bundle(root, "demo")
+
+
+def test_copy_per_production_and_orders_uses_bundle(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "PN1.pdf").write_text("dummy")
+
+    bom_df = pd.DataFrame(
+        [{"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}]
+    )
+
+    dest_root = tmp_path / "bundles"
+    ts = datetime.datetime(2023, 7, 1, 8, 0, 0)
+    bundle = create_export_bundle(dest_root, "Run", timestamp=ts)
+
+    cnt, chosen, bundle_info = copy_per_production_and_orders(
+        str(src),
+        str(bundle["path"]),
+        bom_df,
+        [".pdf"],
+        db,
+        {},
+        {},
+        {},
+        False,
+        client=None,
+        delivery_map={},
+        bundle=bundle,
+    )
+
+    assert cnt == 1
+    assert chosen == {"Laser": "ACME"}
+    assert bundle_info["path"] == bundle["path"]
+    prod_file = Path(bundle_info["path"]) / "Laser" / "PN1.pdf"
+    assert prod_file.exists()
+    latest = dest_root / "latest"
+    assert latest.is_symlink()
+    assert os.readlink(latest) == bundle_info["name"]


### PR DESCRIPTION
## Summary
- introduce a create_export_bundle helper to manage timestamped export folders and latest symlinks
- wire CLI/GUI and copy_per_production_and_orders to pass through bundle metadata
- add regression and CLI tests that exercise export bundle creation, usage, and delivery mappings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cfe95b53b48322a84f9c74c5450ba7