### PR TITLE
Update top folder labels with icons

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1005,19 +1005,19 @@ def start_gui():
 
             # Top folders
             top = tk.Frame(main); top.pack(fill="x", padx=8, pady=6)
-            tk.Label(top, text="Bronmap:").grid(row=0, column=0, sticky="w")
+            tk.Label(top, text="📁 Bronmap:").grid(row=0, column=0, sticky="w")
             self.src_entry = tk.Entry(top, width=60); self.src_entry.grid(row=0, column=1, padx=4)
             tk.Button(top, text="Bladeren", command=self._pick_src).grid(row=0, column=2, padx=4)
             tk.Label(top, text="Projectnr.:").grid(row=0, column=3, sticky="w", padx=(16, 0))
             tk.Entry(top, textvariable=self.project_number_var, width=60).grid(row=0, column=4, padx=4, sticky="w")
 
-            tk.Label(top, text="Bestemmingsmap:").grid(row=1, column=0, sticky="w")
+            tk.Label(top, text="📁 Bestemmingsmap:").grid(row=1, column=0, sticky="w")
             self.dst_entry = tk.Entry(top, width=60); self.dst_entry.grid(row=1, column=1, padx=4)
             tk.Button(top, text="Bladeren", command=self._pick_dst).grid(row=1, column=2, padx=4)
             tk.Label(top, text="Projectnaam:").grid(row=1, column=3, sticky="w", padx=(16, 0))
             tk.Entry(top, textvariable=self.project_name_var, width=60).grid(row=1, column=4, padx=4, sticky="w")
 
-            tk.Label(top, text="Opdrachtgever:").grid(row=2, column=0, sticky="w")
+            tk.Label(top, text="👤 Opdrachtgever:").grid(row=2, column=0, sticky="w")
             self.client_var = tk.StringVar()
             self.client_combo = ttk.Combobox(top, textvariable=self.client_var, state="readonly", width=40)
             self.client_combo.grid(row=2, column=1, padx=4)


### PR DESCRIPTION
## Summary
- update the main tab's top folder labels to include folder and user icons for clarity

## Testing
- `python gui.py`


------
https://chatgpt.com/codex/tasks/task_b_68d138bd9294832293f92aef108b3087