### PR TITLE
Default Zip per productie option

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1054,7 +1054,7 @@ def start_gui():
             self.step_var = tk.IntVar()
             self.dxf_var = tk.IntVar()
             self.dwg_var = tk.IntVar()
-            self.zip_var = tk.IntVar()
+            self.zip_var = tk.IntVar(value=1)
             self.export_date_prefix_var = tk.IntVar()
             self.export_date_suffix_var = tk.IntVar()
             self.bundle_latest_var = tk.IntVar()


### PR DESCRIPTION
## Summary
- default the Zip per productie option to enabled when launching the GUI

## Testing
- python main.py *(fails: requires display server in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d13cf26f24832280599d9da9ffa992