### PR TITLE
Add custom export token for exported files

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -426,6 +426,7 @@ def cli_copy_per_prod(args):
         footer_note=args.note or DEFAULT_FOOTER_NOTE,
         project_number=args.project_number,
         project_name=args.project_name,
+        export_name_token=args.export_token or "",
     )
     print("Gekopieerd:", cnt)
     for k, v in chosen.items():
@@ -570,6 +571,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--project-name",
         dest="project_name",
         help="Projectnaam voor documentkoppen",
+    )
+    cpp.add_argument(
+        "--export-token",
+        dest="export_token",
+        default="",
+        help="Extra toevoeging voor exportbestandsnamen",
     )
     cpp.add_argument(
         "--bundle-latest",

--- a/gui.py
+++ b/gui.py
@@ -1075,6 +1075,7 @@ def start_gui():
             self.zip_var = tk.IntVar(value=1)
             self.export_date_prefix_var = tk.IntVar()
             self.export_date_suffix_var = tk.IntVar()
+            self.export_name_custom_var = tk.StringVar()
             self.bundle_latest_var = tk.IntVar()
             self.bundle_dry_run_var = tk.IntVar()
 
@@ -1115,6 +1116,14 @@ def start_gui():
                 variable=self.export_date_suffix_var,
                 anchor="w",
             ).pack(anchor="w", pady=2)
+            tk.Label(
+                export_name_inner,
+                text="Aangepaste toevoeging:",
+            ).pack(anchor="w", pady=(8, 0))
+            tk.Entry(
+                export_name_inner,
+                textvariable=self.export_name_custom_var,
+            ).pack(anchor="w", fill="x", pady=(0, 2))
             tk.Checkbutton(
                 options_frame,
                 text="Maak snelkoppeling naar nieuwste exportmap",
@@ -1375,7 +1384,9 @@ def start_gui():
             exts = self._selected_exts()
             if not exts or not self.source_folder or not self.dest_folder:
                 messagebox.showwarning("Let op", "Selecteer bron, bestemming en extensies."); return
-            def work():
+            custom_token = self.export_name_custom_var.get().strip()
+
+            def work(token=custom_token):
                 self.status_var.set("Bundelmap voorbereiden...")
                 try:
                     bundle = create_export_bundle(
@@ -1430,13 +1441,15 @@ def start_gui():
                 )
 
                 def _export_name(fname: str) -> str:
-                    if not date_token:
+                    if not (date_prefix or date_suffix or token):
                         return fname
                     stem, ext = os.path.splitext(fname)
-                    if date_prefix:
+                    if date_prefix and date_token:
                         stem = f"{date_token}-{stem}"
-                    if date_suffix:
+                    if date_suffix and date_token:
                         stem = f"{stem}-{date_token}"
+                    if token:
+                        stem = f"{stem}-{token}"
                     return f"{stem}{ext}"
                 cnt = 0
                 for _, paths in idx.items():
@@ -1483,7 +1496,9 @@ def start_gui():
                     messagebox.showwarning("Let op", "Laad eerst een BOM.")
                     return
 
-                def work():
+                custom_token = self.export_name_custom_var.get().strip()
+
+                def work(token=custom_token):
                     self.status_var.set("Bundelmap voorbereiden...")
                     try:
                         bundle = create_export_bundle(
@@ -1562,6 +1577,7 @@ def start_gui():
                         date_suffix_exports=bool(self.export_date_suffix_var.get()),
                         project_number=project_number,
                         project_name=project_name,
+                        export_name_token=token,
                     )
 
                     def on_done():

--- a/orders.py
+++ b/orders.py
@@ -442,6 +442,7 @@ def copy_per_production_and_orders(
     date_suffix_exports: bool = False,
     project_number: str | None = None,
     project_name: str | None = None,
+    export_name_token: str = "",
 ) -> Tuple[int, Dict[str, str]]:
     """Copy files per production and create accompanying order documents.
 
@@ -463,6 +464,9 @@ def copy_per_production_and_orders(
     with ``YYYYMMDD-``. When ``date_suffix_exports`` is ``True`` they will end
     with ``-YYYYMMDD`` before the extension. Both transformations are applied
     consistently to copied files and ZIP archive members.
+
+    When ``export_name_token`` is provided, it is appended to the filename stem
+    before the extension for all exported files, including ZIP members.
     """
     os.makedirs(dest, exist_ok=True)
     file_index = _build_file_index(source, selected_exts)
@@ -480,17 +484,20 @@ def copy_per_production_and_orders(
     today = today_date.strftime("%Y-%m-%d")
     date_token = today_date.strftime("%Y%m%d")
     delivery_map = delivery_map or {}
+    export_name_token = (export_name_token or "").strip()
 
     def _transform_export_name(filename: str) -> str:
         """Apply prefix/suffix date tokens to ``filename`` when requested."""
 
-        if not (date_prefix_exports or date_suffix_exports):
+        if not (date_prefix_exports or date_suffix_exports or export_name_token):
             return filename
         stem, ext = os.path.splitext(filename)
         if date_prefix_exports:
             stem = f"{date_token}-{stem}"
         if date_suffix_exports:
             stem = f"{stem}-{date_token}"
+        if export_name_token:
+            stem = f"{stem}-{export_name_token}"
         return f"{stem}{ext}"
     for prod, rows in prod_to_rows.items():
         prod_folder = os.path.join(dest, prod)

--- a/tests/test_cli_doc_options.py
+++ b/tests/test_cli_doc_options.py
@@ -45,3 +45,4 @@ def test_cli_doc_options_parsing(monkeypatch, tmp_path):
 
     assert captured["doc_type_map"] == {"Laser": "Offerteaanvraag"}
     assert captured["doc_num_map"] == {"Laser": "123", "Plasma": "456"}
+    assert captured["export_name_token"] == ""

--- a/tests/test_export_name_token.py
+++ b/tests/test_export_name_token.py
@@ -1,0 +1,72 @@
+import zipfile
+
+import pandas as pd
+
+import orders
+from models import Supplier
+from orders import copy_per_production_and_orders
+from suppliers_db import SuppliersDB
+
+
+def _make_db() -> SuppliersDB:
+    db = SuppliersDB([
+        Supplier.from_any({"supplier": "ACME"}),
+    ])
+    return db
+
+
+def _build_bom() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1}
+    ])
+
+
+def test_export_token_applied_to_files_and_zip(tmp_path, monkeypatch):
+    monkeypatch.setattr(orders, "SUPPLIERS_DB_FILE", str(tmp_path / "suppliers.json"))
+
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    dest_zip = tmp_path / "dest_zip"
+    src.mkdir()
+    dest.mkdir()
+    dest_zip.mkdir()
+
+    (src / "PN1.pdf").write_text("dummy")
+
+    db = _make_db()
+    bom_df = _build_bom()
+
+    cnt, _ = copy_per_production_and_orders(
+        str(src),
+        str(dest),
+        bom_df,
+        [".pdf"],
+        db,
+        {"Laser": ""},
+        {},
+        {},
+        False,
+        export_name_token="REV-A",
+    )
+    assert cnt == 1
+    exported = dest / "Laser" / "PN1-REV-A.pdf"
+    assert exported.exists()
+
+    cnt_zip, _ = copy_per_production_and_orders(
+        str(src),
+        str(dest_zip),
+        bom_df,
+        [".pdf"],
+        db,
+        {"Laser": ""},
+        {},
+        {},
+        False,
+        zip_parts=True,
+        export_name_token="REV-A",
+    )
+    assert cnt_zip == 1
+    zip_path = dest_zip / "Laser" / "Laser.zip"
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as zf:
+        assert "PN1-REV-A.pdf" in zf.namelist()


### PR DESCRIPTION
## Summary
- add a GUI field to capture a custom export token and apply it to flat and per production copies
- extend copy_per_production_and_orders with an export token parameter and wire it through the CLI
- cover the new behaviour with a pytest that checks file names and ZIP members

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d14a8c2b58832294f4abe9fff7e1b6