### PR TITLE
Add configurable export token placement

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -395,6 +395,16 @@ def cli_copy_per_prod(args):
                 return 2
             prod, num = kv.split("=", 1)
             doc_num_map[prod.strip()] = num.strip()
+    export_token = args.export_token or ""
+    if args.export_token_enabled is None:
+        token_enabled = bool(export_token)
+    else:
+        token_enabled = bool(args.export_token_enabled) and bool(export_token)
+    token_prefix = bool(args.export_token_prefix)
+    if args.export_token_suffix is None:
+        token_suffix = token_enabled
+    else:
+        token_suffix = bool(args.export_token_suffix)
     bundle = create_export_bundle(
         args.dest,
         args.project_number,
@@ -426,7 +436,10 @@ def cli_copy_per_prod(args):
         footer_note=args.note or DEFAULT_FOOTER_NOTE,
         project_number=args.project_number,
         project_name=args.project_name,
-        export_name_token=args.export_token or "",
+        export_name_token=export_token,
+        export_name_token_enabled=token_enabled,
+        export_name_token_prefix=token_prefix,
+        export_name_token_suffix=token_suffix,
     )
     print("Gekopieerd:", cnt)
     for k, v in chosen.items():
@@ -577,6 +590,27 @@ def build_parser() -> argparse.ArgumentParser:
         dest="export_token",
         default="",
         help="Extra toevoeging voor exportbestandsnamen",
+    )
+    cpp.add_argument(
+        "--export-token-enabled",
+        dest="export_token_enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Schakel de aangepaste toevoeging in of uit (standaard automatisch)",
+    )
+    cpp.add_argument(
+        "--export-token-prefix",
+        dest="export_token_prefix",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Plaats de toevoeging als prefix",
+    )
+    cpp.add_argument(
+        "--export-token-suffix",
+        dest="export_token_suffix",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Plaats de toevoeging als suffix (standaard wanneer actief)",
     )
     cpp.add_argument(
         "--bundle-latest",

--- a/tests/test_export_name_token.py
+++ b/tests/test_export_name_token.py
@@ -1,18 +1,22 @@
 import zipfile
 
 import pandas as pd
+import pytest
 
+import cli
 import orders
+from cli import build_parser, cli_copy_per_prod
+from clients_db import ClientsDB
+from delivery_addresses_db import DeliveryAddressesDB
 from models import Supplier
 from orders import copy_per_production_and_orders
 from suppliers_db import SuppliersDB
 
 
 def _make_db() -> SuppliersDB:
-    db = SuppliersDB([
+    return SuppliersDB([
         Supplier.from_any({"supplier": "ACME"}),
     ])
-    return db
 
 
 def _build_bom() -> pd.DataFrame:
@@ -21,12 +25,20 @@ def _build_bom() -> pd.DataFrame:
     ])
 
 
-def test_export_token_applied_to_files_and_zip(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("prefix", "suffix", "expected"),
+    [
+        (False, True, "PN1-REV-A.pdf"),
+        (True, False, "REV-A-PN1.pdf"),
+        (True, True, "REV-A-PN1-REV-A.pdf"),
+    ],
+)
+def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected):
     monkeypatch.setattr(orders, "SUPPLIERS_DB_FILE", str(tmp_path / "suppliers.json"))
 
     src = tmp_path / "src"
-    dest = tmp_path / "dest"
-    dest_zip = tmp_path / "dest_zip"
+    dest = tmp_path / f"dest_{prefix}_{suffix}"
+    dest_zip = tmp_path / f"dest_zip_{prefix}_{suffix}"
     src.mkdir()
     dest.mkdir()
     dest_zip.mkdir()
@@ -47,9 +59,12 @@ def test_export_token_applied_to_files_and_zip(tmp_path, monkeypatch):
         {},
         False,
         export_name_token="REV-A",
+        export_name_token_enabled=True,
+        export_name_token_prefix=prefix,
+        export_name_token_suffix=suffix,
     )
     assert cnt == 1
-    exported = dest / "Laser" / "PN1-REV-A.pdf"
+    exported = dest / "Laser" / expected
     assert exported.exists()
 
     cnt_zip, _ = copy_per_production_and_orders(
@@ -64,9 +79,89 @@ def test_export_token_applied_to_files_and_zip(tmp_path, monkeypatch):
         False,
         zip_parts=True,
         export_name_token="REV-A",
+        export_name_token_enabled=True,
+        export_name_token_prefix=prefix,
+        export_name_token_suffix=suffix,
     )
     assert cnt_zip == 1
     zip_path = dest_zip / "Laser" / "Laser.zip"
     assert zip_path.exists()
     with zipfile.ZipFile(zip_path) as zf:
-        assert "PN1-REV-A.pdf" in zf.namelist()
+        assert expected in zf.namelist()
+
+
+def test_export_token_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(orders, "SUPPLIERS_DB_FILE", str(tmp_path / "suppliers.json"))
+
+    src = tmp_path / "src"
+    dest = tmp_path / "dest_disabled"
+    src.mkdir()
+    dest.mkdir()
+    (src / "PN1.pdf").write_text("dummy")
+
+    db = _make_db()
+    bom_df = _build_bom()
+
+    cnt, _ = copy_per_production_and_orders(
+        str(src),
+        str(dest),
+        bom_df,
+        [".pdf"],
+        db,
+        {"Laser": ""},
+        {},
+        {},
+        False,
+        export_name_token="REV-A",
+        export_name_token_enabled=False,
+        export_name_token_prefix=True,
+        export_name_token_suffix=True,
+    )
+    assert cnt == 1
+    exported = dest / "Laser" / "PN1.pdf"
+    assert exported.exists()
+
+
+def test_cli_export_token_flags(monkeypatch, tmp_path):
+    parser = build_parser()
+    args = parser.parse_args([
+        "copy-per-prod",
+        "--source",
+        str(tmp_path / "src"),
+        "--dest",
+        str(tmp_path / "dst"),
+        "--bom",
+        str(tmp_path / "bom.xlsx"),
+        "--exts",
+        "pdf",
+        "--export-token",
+        "REV-A",
+        "--export-token-enabled",
+        "--export-token-prefix",
+        "--no-export-token-suffix",
+    ])
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "dst").mkdir()
+    monkeypatch.setattr(cli, "load_bom", lambda path: _build_bom())
+
+    sdb = _make_db()
+    monkeypatch.setattr(SuppliersDB, "load", classmethod(lambda cls, path: sdb))
+    cdb = ClientsDB([])
+    monkeypatch.setattr(ClientsDB, "load", classmethod(lambda cls, path: cdb))
+    ddb = DeliveryAddressesDB([])
+    monkeypatch.setattr(DeliveryAddressesDB, "load", classmethod(lambda cls, path: ddb))
+
+    captured = {}
+
+    def fake_copy(*args, **kwargs):
+        captured.update(kwargs)
+        return 0, {}
+
+    monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
+    cli_copy_per_prod(args)
+
+    assert captured["export_name_token"] == "REV-A"
+    assert captured["export_name_token_enabled"] is True
+    assert captured["export_name_token_prefix"] is True
+    assert captured["export_name_token_suffix"] is False


### PR DESCRIPTION
## Summary
- add GUI controls for enabling and positioning export name tokens
- update export copy routines and CLI wiring to honour prefix/suffix placement
- extend export-name tests to cover prefix/suffix combinations and CLI options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d14f1814808322bac681e75f2f9262