### PR TITLE
Refactor export filename customization to separate prefix/suffix tokens

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -395,16 +395,10 @@ def cli_copy_per_prod(args):
                 return 2
             prod, num = kv.split("=", 1)
             doc_num_map[prod.strip()] = num.strip()
-    export_token = args.export_token or ""
-    if args.export_token_enabled is None:
-        token_enabled = bool(export_token)
-    else:
-        token_enabled = bool(args.export_token_enabled) and bool(export_token)
-    token_prefix = bool(args.export_token_prefix)
-    if args.export_token_suffix is None:
-        token_suffix = token_enabled
-    else:
-        token_suffix = bool(args.export_token_suffix)
+    export_prefix_text = (args.export_prefix_text or "").strip()
+    export_suffix_text = (args.export_suffix_text or "").strip()
+    export_prefix_enabled = args.export_prefix_enabled
+    export_suffix_enabled = args.export_suffix_enabled
     bundle = create_export_bundle(
         args.dest,
         args.project_number,
@@ -436,10 +430,10 @@ def cli_copy_per_prod(args):
         footer_note=args.note or DEFAULT_FOOTER_NOTE,
         project_number=args.project_number,
         project_name=args.project_name,
-        export_name_token=export_token,
-        export_name_token_enabled=token_enabled,
-        export_name_token_prefix=token_prefix,
-        export_name_token_suffix=token_suffix,
+        export_name_prefix_text=export_prefix_text,
+        export_name_prefix_enabled=export_prefix_enabled,
+        export_name_suffix_text=export_suffix_text,
+        export_name_suffix_enabled=export_suffix_enabled,
     )
     print("Gekopieerd:", cnt)
     for k, v in chosen.items():
@@ -586,31 +580,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Projectnaam voor documentkoppen",
     )
     cpp.add_argument(
-        "--export-token",
-        dest="export_token",
+        "--export-prefix-text",
+        dest="export_prefix_text",
         default="",
-        help="Extra toevoeging voor exportbestandsnamen",
+        help="Extra prefix voor exportbestandsnamen",
     )
     cpp.add_argument(
-        "--export-token-enabled",
-        dest="export_token_enabled",
+        "--export-prefix-enabled",
+        dest="export_prefix_enabled",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Schakel de aangepaste toevoeging in of uit (standaard automatisch)",
+        help="Schakel de aangepaste prefix in of uit (standaard automatisch)",
     )
     cpp.add_argument(
-        "--export-token-prefix",
-        dest="export_token_prefix",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Plaats de toevoeging als prefix",
+        "--export-suffix-text",
+        dest="export_suffix_text",
+        default="",
+        help="Extra suffix voor exportbestandsnamen",
     )
     cpp.add_argument(
-        "--export-token-suffix",
-        dest="export_token_suffix",
+        "--export-suffix-enabled",
+        dest="export_suffix_enabled",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Plaats de toevoeging als suffix (standaard wanneer actief)",
+        help="Schakel de aangepaste suffix in of uit (standaard automatisch)",
     )
     cpp.add_argument(
         "--bundle-latest",

--- a/tests/test_cli_doc_options.py
+++ b/tests/test_cli_doc_options.py
@@ -45,4 +45,5 @@ def test_cli_doc_options_parsing(monkeypatch, tmp_path):
 
     assert captured["doc_type_map"] == {"Laser": "Offerteaanvraag"}
     assert captured["doc_num_map"] == {"Laser": "123", "Plasma": "456"}
-    assert captured["export_name_token"] == ""
+    assert captured["export_name_prefix_text"] == ""
+    assert captured["export_name_suffix_text"] == ""

--- a/tests/test_export_name_token.py
+++ b/tests/test_export_name_token.py
@@ -58,10 +58,10 @@ def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected)
         {},
         {},
         False,
-        export_name_token="REV-A",
-        export_name_token_enabled=True,
-        export_name_token_prefix=prefix,
-        export_name_token_suffix=suffix,
+        export_name_prefix_text="REV-A",
+        export_name_prefix_enabled=prefix,
+        export_name_suffix_text="REV-A",
+        export_name_suffix_enabled=suffix,
     )
     assert cnt == 1
     exported = dest / "Laser" / expected
@@ -78,10 +78,10 @@ def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected)
         {},
         False,
         zip_parts=True,
-        export_name_token="REV-A",
-        export_name_token_enabled=True,
-        export_name_token_prefix=prefix,
-        export_name_token_suffix=suffix,
+        export_name_prefix_text="REV-A",
+        export_name_prefix_enabled=prefix,
+        export_name_suffix_text="REV-A",
+        export_name_suffix_enabled=suffix,
     )
     assert cnt_zip == 1
     zip_path = dest_zip / "Laser" / "Laser.zip"
@@ -112,10 +112,10 @@ def test_export_token_disabled(tmp_path, monkeypatch):
         {},
         {},
         False,
-        export_name_token="REV-A",
-        export_name_token_enabled=False,
-        export_name_token_prefix=True,
-        export_name_token_suffix=True,
+        export_name_prefix_text="REV-A",
+        export_name_prefix_enabled=False,
+        export_name_suffix_text="REV-A",
+        export_name_suffix_enabled=False,
     )
     assert cnt == 1
     exported = dest / "Laser" / "PN1.pdf"
@@ -134,11 +134,12 @@ def test_cli_export_token_flags(monkeypatch, tmp_path):
         str(tmp_path / "bom.xlsx"),
         "--exts",
         "pdf",
-        "--export-token",
+        "--export-prefix-text",
         "REV-A",
-        "--export-token-enabled",
-        "--export-token-prefix",
-        "--no-export-token-suffix",
+        "--export-prefix-enabled",
+        "--export-suffix-text",
+        "REV-A",
+        "--no-export-suffix-enabled",
     ])
 
     (tmp_path / "src").mkdir()
@@ -161,7 +162,7 @@ def test_cli_export_token_flags(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)
 
-    assert captured["export_name_token"] == "REV-A"
-    assert captured["export_name_token_enabled"] is True
-    assert captured["export_name_token_prefix"] is True
-    assert captured["export_name_token_suffix"] is False
+    assert captured["export_name_prefix_text"] == "REV-A"
+    assert captured["export_name_prefix_enabled"] is True
+    assert captured["export_name_suffix_text"] == "REV-A"
+    assert captured["export_name_suffix_enabled"] is False


### PR DESCRIPTION
## Summary
- split the custom export token into dedicated prefix/suffix fields and toggles in the GUI
- plumb the new prefix/suffix options through the CLI and copy_per_production logic
- adjust tests to cover the updated export name behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d157841e6483229f3f52850aafeab8