### PR TITLE
Distribute custom BOM extra width across all columns

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -332,8 +332,31 @@ class BOMCustomTab(ttk.Frame):
             return
 
         total_min_width = sum(widths)
-        if available_width > total_min_width:
-            widths[-1] += available_width - total_min_width
+        if available_width > total_min_width and widths:
+            extra_width = available_width - total_min_width
+            weights = [max(min_widths_map.get(idx, 1), 1) for idx in column_indices]
+            total_weight = sum(weights)
+            if total_weight <= 0:
+                total_weight = len(weights)
+                weights = [1] * len(weights)
+
+            base_additions = []
+            remainders = []
+            for idx, (width, weight) in enumerate(zip(widths, weights)):
+                numerator = extra_width * weight
+                addition = numerator // total_weight
+                base_additions.append(addition)
+                remainders.append((numerator % total_weight, idx))
+
+            remainder = extra_width - sum(base_additions)
+            if remainder > 0:
+                remainders.sort(reverse=True)
+                for _, idx in remainders[:remainder]:
+                    base_additions[idx] += 1
+
+            widths = [width + addition for width, addition in zip(widths, base_additions)]
+
+        widths = [max(width, min_widths_map.get(idx, 0)) for idx, width in enumerate(widths)]
 
         self._in_container_resize = True
         try:


### PR DESCRIPTION
## Summary
- distribute available extra width across all BOM columns during container resize instead of allocating it all to the last column
- keep each column at or above its minimum width and update the sheet widths without altering the existing refresh guard

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d263dbaffc83229a86be1f54e3a59a