### PR TITLE
Ensure BOM tab keeps spare empty row

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -127,6 +127,7 @@ class BOMCustomTab(ttk.Frame):
         "Weight (kg)",
         "Surface Area (m²)",
     )
+    DEFAULT_EMPTY_ROWS: int = 20
     COLUMN_PADDING: int = 24
     TRAILING_GUTTER: int = 12
 
@@ -196,7 +197,7 @@ class BOMCustomTab(ttk.Frame):
             )
         )
         self.sheet.set_sheet_data([])
-        self._ensure_minimum_rows()
+        self._ensure_minimum_rows(self.DEFAULT_EMPTY_ROWS)
         self.sheet.grid(row=0, column=0, sticky="nsew")
         self._sheet_container = container
         container.bind("<Configure>", self._on_container_resize)
@@ -377,7 +378,7 @@ class BOMCustomTab(ttk.Frame):
             self._auto_resize_columns(range(len(self.HEADERS)))
             self._apply_row_striping()
             return
-        self._ensure_minimum_rows()
+        self._ensure_minimum_rows(self.DEFAULT_EMPTY_ROWS)
         self._auto_resize_columns(range(len(self.HEADERS)))
         self._apply_row_striping()
 
@@ -528,7 +529,7 @@ class BOMCustomTab(ttk.Frame):
         if not messagebox.askyesno("Bevestigen", "Alle custom BOM-data verwijderen?", parent=self):
             return
         self.sheet.set_sheet_data([])
-        self._ensure_minimum_rows()
+        self._ensure_minimum_rows(self.DEFAULT_EMPTY_ROWS)
         self._auto_resize_columns(range(len(self.HEADERS)))
         self._apply_row_striping()
         self._push_undo("clear", data_before, self._snapshot_data(), [])
@@ -560,6 +561,10 @@ class BOMCustomTab(ttk.Frame):
             self._push_undo("edit", self._edit_snapshot, after, [(row, col)])
             self._update_status(f"Cel ({row + 1}, {col + 1}) bijgewerkt.")
             self._auto_resize_columns([col])
+        total_rows = self.sheet.get_total_rows()
+        if row >= total_rows - 1:
+            self._ensure_minimum_rows(row + 2)
+            self._apply_row_striping()
         self._edit_snapshot = None
         self._edit_cell = None
 


### PR DESCRIPTION
## Summary
- add a DEFAULT_EMPTY_ROWS constant to control the minimum empty rows in the BOM sheet
- ensure the BOM tab always restores at least the default number of empty rows
- append a fresh empty row when editing the last row to keep an empty slot available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2959da9fc8322848190909c0cf355