### PR TITLE
Enable additional edit bindings in custom BOM sheet

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -192,8 +192,12 @@ class BOMCustomTab(ttk.Frame):
                 "column_select",
                 "column_width_resize",
                 "double_click_column_resize",
+                "double_click_select",
                 "copy",
                 "edit_cell",
+                "tab_key",
+                "arrowkeys",
+                "enter_key",
             )
         )
         self.sheet.set_sheet_data([])


### PR DESCRIPTION
## Summary
- allow the custom BOM tksheet to respond to double-click and keyboard edit triggers

## Testing
- python -m compileall bom_custom_tab.py
- python main.py

------
https://chatgpt.com/codex/tasks/task_b_68d2a0d2e7088322bc29306784eeac5e