### PR TITLE
Normalize doc numbers for zip exports

### DIFF
--- a/tests/test_combine_pdfs.py
+++ b/tests/test_combine_pdfs.py
@@ -27,7 +27,7 @@ def test_combine_handles_loose_files_and_zip(tmp_path):
     # production with PDFs only inside a zip archive
     prod2 = dest / "prod2"
     prod2.mkdir()
-    zip_path = prod2 / "prod2.zip"
+    zip_path = prod2 / "prod2_BB-123.zip"
     with zipfile.ZipFile(zip_path, "w") as zf:
         for name in ["c.pdf", "d.pdf"]:
             tmp = prod2 / name

--- a/tests/test_export_name_token.py
+++ b/tests/test_export_name_token.py
@@ -1,3 +1,4 @@
+import re
 import zipfile
 
 import pandas as pd
@@ -84,8 +85,11 @@ def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected)
         export_name_suffix_enabled=suffix,
     )
     assert cnt_zip == 1
-    zip_path = dest_zip / "Laser" / "Laser.zip"
-    assert zip_path.exists()
+    zip_dir = dest_zip / "Laser"
+    zip_files = sorted(zip_dir.glob("Laser*.zip"))
+    assert len(zip_files) == 1
+    zip_path = zip_files[0]
+    assert re.fullmatch(r"Laser(?:_.+)?", zip_path.stem)
     with zipfile.ZipFile(zip_path) as zf:
         assert expected in zf.namelist()
 


### PR DESCRIPTION
## Summary
- normalize document numbers before exporting archives so ZIP filenames reuse the _{doc_num} suffix
- update PDF combination to detect production ZIPs that include the optional document-number suffix
- extend export and document-number tests to cover the new ZIP naming pattern and ensure transformed members are present

## Testing
- `pytest tests/test_export_name_token.py tests/test_doc_numbers.py tests/test_combine_pdfs.py`


------
https://chatgpt.com/codex/tasks/task_b_68d2b04d58c88322850598e407559aca