### PR TITLE
Deduplicate exported part files per production

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -544,19 +544,23 @@ def copy_per_production_and_orders(
             zip_path = os.path.join(prod_folder, zip_name)
             zf = zipfile.ZipFile(zip_path, "w")
 
+        processed_pairs: set[tuple[str, str]] = set()
         for row in rows:
             pn = str(row["PartNumber"])
             files = file_index.get(pn, [])
             for src_file in files:
                 transformed = _transform_export_name(os.path.basename(src_file))
+                combo = (src_file, transformed)
+                if combo in processed_pairs:
+                    continue
+                processed_pairs.add(combo)
                 if zip_parts:
                     if zf is not None:
                         zf.write(src_file, arcname=transformed)
-                        count_copied += 1
                 else:
                     dst = os.path.join(prod_folder, transformed)
                     shutil.copy2(src_file, dst)
-                    count_copied += 1
+                count_copied += 1
 
         if zf is not None:
             zf.close()

--- a/tests/test_export_dedup.py
+++ b/tests/test_export_dedup.py
@@ -1,0 +1,68 @@
+import zipfile
+
+import pandas as pd
+
+from models import Supplier
+from orders import copy_per_production_and_orders
+from suppliers_db import SuppliersDB
+
+
+def _make_db() -> SuppliersDB:
+    return SuppliersDB([
+        Supplier.from_any({"supplier": "ACME"}),
+    ])
+
+
+def _build_bom() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1},
+        {"PartNumber": "PN1", "Description": "", "Production": "Laser", "Aantal": 1},
+    ])
+
+
+def test_duplicate_parts_single_export(tmp_path):
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    dest_zip = tmp_path / "dest_zip"
+    src.mkdir()
+    dest.mkdir()
+    dest_zip.mkdir()
+
+    (src / "PN1.pdf").write_text("dummy")
+
+    db = _make_db()
+    bom_df = _build_bom()
+
+    cnt, _ = copy_per_production_and_orders(
+        str(src),
+        str(dest),
+        bom_df,
+        [".pdf"],
+        db,
+        {"Laser": "ACME"},
+        {},
+        {},
+        False,
+    )
+    assert cnt == 1
+    exported_files = list((dest / "Laser").glob("PN1*.pdf"))
+    assert len(exported_files) == 1
+
+    cnt_zip, _ = copy_per_production_and_orders(
+        str(src),
+        str(dest_zip),
+        bom_df,
+        [".pdf"],
+        db,
+        {"Laser": "ACME"},
+        {},
+        {},
+        False,
+        zip_parts=True,
+    )
+    assert cnt_zip == 1
+    zip_path = dest_zip / "Laser" / "Laser.zip"
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        assert names.count("PN1.pdf") == 1


### PR DESCRIPTION
## Summary
- avoid copying or zipping the same source/target export combination more than once per production
- add a regression test ensuring duplicate part numbers yield a single export file and zip member

## Testing
- pytest tests/test_export_dedup.py


------
https://chatgpt.com/codex/tasks/task_b_68d2d0f5abac832289ee4b3adfbbb7f5