### PR TITLE
Cache sorted suppliers for production selection

### DIFF
--- a/tests/test_pick_supplier.py
+++ b/tests/test_pick_supplier.py
@@ -1,0 +1,22 @@
+from models import Supplier
+from orders import pick_supplier_for_production
+from suppliers_db import SuppliersDB
+
+
+def test_pick_supplier_with_prefetched_list(tmp_path, monkeypatch):
+    """Providing a cached supplier list keeps the selection identical."""
+
+    monkeypatch.chdir(tmp_path)
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+    db.upsert(Supplier.from_any({"supplier": "BETA"}))
+
+    overrides = {"Laser": "BETA"}
+    prefetched = db.suppliers_sorted()
+
+    direct = pick_supplier_for_production("Laser", db, overrides)
+    cached = pick_supplier_for_production(
+        "Laser", db, overrides, suppliers_sorted=prefetched
+    )
+
+    assert cached == direct


### PR DESCRIPTION
## Summary
- allow `pick_supplier_for_production` to accept a pre-sorted supplier list
- reuse the cached list in `copy_per_production_and_orders` to avoid repeated database lookups
- add a regression test confirming supplier selection stays the same with cached lists

## Testing
- pytest tests/test_defaults_persist.py tests/self_test.py tests/test_pick_supplier.py

------
https://chatgpt.com/codex/tasks/task_b_68d2d0ece6bc8322bc1f5a8721d71930