### PR TITLE
Use deflated compression for production archives with fallback

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -542,7 +542,30 @@ def copy_per_production_and_orders(
         if zip_parts:
             zip_name = f"{prod}{num_part}.zip"
             zip_path = os.path.join(prod_folder, zip_name)
-            zf = zipfile.ZipFile(zip_path, "w")
+            try:
+                zf = zipfile.ZipFile(
+                    zip_path,
+                    "w",
+                    compression=zipfile.ZIP_DEFLATED,
+                    compresslevel=6,
+                )
+            except TypeError:
+                # ``compresslevel`` not supported (older Python). Retry without it.
+                zf = zipfile.ZipFile(
+                    zip_path,
+                    "w",
+                    compression=zipfile.ZIP_DEFLATED,
+                )
+            except (RuntimeError, NotImplementedError):
+                print(
+                    "[WAARSCHUWING] ZIP_DEFLATED niet beschikbaar, val terug op ZIP_STORED",
+                    file=sys.stderr,
+                )
+                zf = zipfile.ZipFile(
+                    zip_path,
+                    "w",
+                    compression=zipfile.ZIP_STORED,
+                )
 
         for row in rows:
             pn = str(row["PartNumber"])

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -213,4 +213,9 @@ def test_doc_number_applied_to_zip_filename(tmp_path):
 
     with zipfile.ZipFile(zip_path) as zf:
         assert "PN1.pdf" in zf.namelist()
+        info = zf.getinfo("PN1.pdf")
+        if getattr(zipfile, "zlib", None):
+            assert info.compress_type == zipfile.ZIP_DEFLATED
+        else:
+            assert info.compress_type == zipfile.ZIP_STORED
 

--- a/tests/test_export_name_token.py
+++ b/tests/test_export_name_token.py
@@ -92,6 +92,11 @@ def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected)
     assert re.fullmatch(r"Laser(?:_.+)?", zip_path.stem)
     with zipfile.ZipFile(zip_path) as zf:
         assert expected in zf.namelist()
+        info = zf.getinfo(expected)
+        if getattr(zipfile, "zlib", None):
+            assert info.compress_type == zipfile.ZIP_DEFLATED
+        else:
+            assert info.compress_type == zipfile.ZIP_STORED
 
 
 def test_export_token_disabled(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- write production ZIP archives with deflated compression and fall back to stored mode when unavailable
- warn operators when compression support is missing and keep compatibility with older Python versions
- extend ZIP-related tests to assert compression is applied while preserving existing behaviour

## Testing
- pytest tests/test_doc_numbers.py tests/test_export_name_token.py

------
https://chatgpt.com/codex/tasks/task_b_68d2d11123d08322888b0886d9457ddc