### PR TITLE
Remove settings button from tabs wrapper

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1257,11 +1257,6 @@ def start_gui():
             self.nb.add(self.settings_frame, text="⚙ Settings")
 
             self.nb.grid(row=0, column=0, sticky="nsew")
-            tk.Button(
-                tabs_wrapper,
-                text="⚙",
-                command=lambda: self.nb.select(self.settings_frame),
-            ).grid(row=0, column=1, sticky="ne", padx=(4, 12), pady=(4, 0))
 
             # Top folders
             top = tk.Frame(main); top.pack(fill="x", padx=8, pady=6)


### PR DESCRIPTION
## Summary
- remove the extra settings button next to the notebook tabs so the notebook alone occupies the grid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d2e3c746948322b79fdee04571516f