### PR TITLE
Handle Notebook focus children in tab button layout

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1058,6 +1058,10 @@ def start_gui():
                     cleaned = []
                     for child_element, child_options in layout_items:
                         if child_element == "Notebook.focus":
+                            if child_options:
+                                children = child_options.get("children")
+                                if children:
+                                    cleaned.extend(_remove_focus(children))
                             continue
                         if child_options:
                             new_child_options = deepcopy(child_options)


### PR DESCRIPTION
## Summary
- recursively splice `Notebook.focus` children into the parent when configuring the tab-like button layout

## Testing
- python -m compileall gui.py

------
https://chatgpt.com/codex/tasks/task_b_68d2f9ee4da083229a7a9149024bbd19