### PR TITLE
Remove extra settings button from notebook

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1075,7 +1075,9 @@ def start_gui():
                     return cleaned
 
                 if tab_layout:
-                    style.layout("Tab.TButton", _remove_focus(tab_layout))
+                    cleaned_layout = _remove_focus(tab_layout)
+                    style.layout("TNotebook.Tab", cleaned_layout)
+                    style.layout("Tab.TButton", cleaned_layout)
 
                 tab_config = {}
                 for opt in ("padding", "background", "foreground", "font", "borderwidth", "relief"):
@@ -1093,15 +1095,6 @@ def start_gui():
                 padding = style.lookup("TNotebook.Tab", "padding")
                 if padding in (None, ""):
                     style.configure("Tab.TButton", padding=(12, 4))
-
-                bg_color = (
-                    style.lookup("TNotebook.Tab", "background")
-                    or style.lookup("TNotebook", "background")
-                    or style.lookup("TFrame", "background")
-                    or self.cget("background")
-                )
-                style.configure("SettingsTabContainer.TFrame", background=bg_color)
-                style.map("SettingsTabContainer.TFrame", background=[("!disabled", bg_color)])
 
             _configure_tab_like_button_style()
             self.title("Filehopper")
@@ -1199,22 +1192,7 @@ def start_gui():
             tabs_container.pack(fill="both", expand=True)
 
             self.nb = ttk.Notebook(tabs_container)
-            self.nb.pack(side="left", fill="both", expand=True)
-
-            settings_tab_container = ttk.Frame(
-                tabs_container, style="SettingsTabContainer.TFrame"
-            )
-            settings_tab_container.pack(side="left", fill="y", padx=(4, 0))
-            settings_tab_container.bind("<Button-1>", self._show_settings_tab)
-
-            self.settings_tab_button = ttk.Button(
-                settings_tab_container,
-                text="⚙ Settings",
-                style="Tab.TButton",
-                command=self._show_settings_tab,
-                takefocus=True,
-            )
-            self.settings_tab_button.pack(fill="both")
+            self.nb.pack(fill="both", expand=True)
             self.custom_bom_tab = BOMCustomTab(
                 self.nb,
                 app_name="Filehopper",
@@ -1240,9 +1218,6 @@ def start_gui():
 
             self.settings_frame = SettingsFrame(self.nb, self)
             self.nb.add(self.settings_frame, text="⚙ Settings")
-            self.nb.hide(self.settings_frame)
-            self.nb.bind("<<NotebookTabChanged>>", self._on_tab_changed)
-            self._on_tab_changed()
 
             # Top folders
             top = tk.Frame(main); top.pack(fill="x", padx=8, pady=6)
@@ -1438,22 +1413,6 @@ def start_gui():
             self.status_var = tk.StringVar(value="Klaar")
             tk.Label(main, textvariable=self.status_var, anchor="w").pack(fill="x", padx=8, pady=(0,8))
             self._save_settings()
-
-        def _show_settings_tab(self, _event=None):
-            self.nb.tab(self.settings_frame, state="normal")
-            self.nb.select(self.settings_frame)
-            self.settings_tab_button.focus_set()
-            if _event is not None and _event.widget is not self.settings_tab_button:
-                return "break"
-
-        def _on_tab_changed(self, _event=None):
-            current = self.nb.select()
-            settings_id = str(self.settings_frame)
-            if current == settings_id:
-                self.settings_tab_button.state(["pressed"])
-            else:
-                self.settings_tab_button.state(["!pressed"])
-                self.nb.tab(self.settings_frame, state="hidden")
 
         def _on_db_change(self):
             self._refresh_clients_combo()


### PR DESCRIPTION
## Summary
- remove the standalone settings button next to the notebook and show the settings tab directly within the tab bar
- remove the dotted focus highlight from notebook tabs so the clicked tab no longer shows a focus box

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d3997100dc8322b5e5c3c1850bcd64