### PR TITLE
Allow configuring file extensions via settings

### DIFF
--- a/app_settings.py
+++ b/app_settings.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from dataclasses import dataclass, field, asdict, fields
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, List, Optional
 
 from suppliers_db import SUPPLIERS_DB_FILE
 
@@ -30,16 +31,134 @@ def _as_str(value: Any) -> str:
     return str(value)
 
 
+def _normalize_patterns(patterns: Iterable[Any]) -> List[str]:
+    cleaned: List[str] = []
+    seen = set()
+    for raw in patterns:
+        if not isinstance(raw, str):
+            continue
+        pat = raw.strip()
+        if not pat:
+            continue
+        if not pat.startswith("."):
+            pat = "." + pat.lstrip(".")
+        pat = pat.lower()
+        if pat not in seen:
+            cleaned.append(pat)
+            seen.add(pat)
+    return cleaned
+
+
+def _normalize_key(value: str) -> str:
+    base = [
+        (ch.lower() if ch.isalnum() else "_")
+        for ch in value.strip()
+    ]
+    key = "".join(base).strip("_")
+    return key or "ext"
+
+
+@dataclass
+class FileExtensionSetting:
+    key: str
+    label: str
+    patterns: List[str] = field(default_factory=list)
+    enabled: bool = False
+
+    @classmethod
+    def from_any(cls, data: Any) -> "FileExtensionSetting":
+        if isinstance(data, FileExtensionSetting):
+            return cls(
+                key=data.key,
+                label=data.label,
+                patterns=list(data.patterns),
+                enabled=bool(data.enabled),
+            )
+        if not isinstance(data, dict):
+            raise ValueError("file extension data must be a mapping")
+
+        key = _as_str(data.get("key", "")).strip().lower()
+        label = _as_str(data.get("label", "")).strip()
+        patterns_raw = data.get("patterns", [])
+        if isinstance(patterns_raw, str):
+            patterns_iter = [patterns_raw]
+        else:
+            patterns_iter = patterns_raw
+        patterns = _normalize_patterns(patterns_iter if patterns_iter is not None else [])
+
+        if not key:
+            if patterns:
+                key = patterns[0].lstrip(".")
+            elif label:
+                key = _normalize_key(label)
+        if not key:
+            key = "ext"
+        key = _normalize_key(key)
+
+        if not label:
+            if patterns:
+                label = ", ".join(patterns)
+            else:
+                label = key.upper()
+
+        if not patterns:
+            patterns = ["." + key]
+
+        enabled = _as_bool(data.get("enabled", False))
+
+        return cls(key=key, label=label, patterns=patterns, enabled=enabled)
+
+    @classmethod
+    def from_user_input(
+        cls,
+        label: str,
+        patterns_text: str,
+        enabled: bool,
+        *,
+        key: Optional[str] = None,
+    ) -> "FileExtensionSetting":
+        label = _as_str(label).strip()
+        raw = patterns_text.replace(";", ",")
+        parts: List[str] = []
+        for chunk in raw.split(","):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            parts.extend(chunk.split())
+        patterns = _normalize_patterns(parts)
+        if not patterns:
+            raise ValueError("Geef minstens één bestandsextensie op")
+        if not label:
+            label = ", ".join(patterns)
+        if key:
+            norm_key = _normalize_key(key)
+        else:
+            norm_key = _normalize_key(patterns[0].lstrip("."))
+        return cls(key=norm_key, label=label, patterns=patterns, enabled=bool(enabled))
+
+
+DEFAULT_FILE_EXTENSIONS: List[FileExtensionSetting] = [
+    FileExtensionSetting(key="pdf", label="PDF (.pdf)", patterns=[".pdf"], enabled=False),
+    FileExtensionSetting(
+        key="step",
+        label="STEP (.step, .stp)",
+        patterns=[".step", ".stp"],
+        enabled=False,
+    ),
+    FileExtensionSetting(key="dxf", label="DXF (.dxf)", patterns=[".dxf"], enabled=False),
+    FileExtensionSetting(key="dwg", label="DWG (.dwg)", patterns=[".dwg"], enabled=False),
+]
+
+
 @dataclass
 class AppSettings:
     source_folder: str = ""
     dest_folder: str = ""
     project_number: str = ""
     project_name: str = ""
-    pdf: bool = False
-    step: bool = False
-    dxf: bool = False
-    dwg: bool = False
+    file_extensions: List[FileExtensionSetting] = field(
+        default_factory=lambda: deepcopy(DEFAULT_FILE_EXTENSIONS)
+    )
     zip_per_production: bool = True
     export_date_prefix: bool = False
     export_date_suffix: bool = False
@@ -75,16 +194,74 @@ class AppSettings:
         inst = cls()
         if not isinstance(data, dict):
             return inst
+        legacy_flags = {}
+        for key in ("pdf", "step", "dxf", "dwg"):
+            if key in data:
+                legacy_flags[key] = _as_bool(data.get(key))
+
         for field_info in fields(cls):
             name = field_info.name
             if name == "_path":
                 continue
             if name not in data:
+                if name == "file_extensions" and legacy_flags:
+                    setattr(
+                        inst,
+                        name,
+                        [
+                            FileExtensionSetting(
+                                key=ext.key,
+                                label=ext.label,
+                                patterns=list(ext.patterns),
+                                enabled=legacy_flags.get(ext.key, ext.enabled),
+                            )
+                            for ext in DEFAULT_FILE_EXTENSIONS
+                        ],
+                    )
                 continue
             cur_val = getattr(inst, name)
             raw = data.get(name)
             if isinstance(cur_val, bool):
                 setattr(inst, name, _as_bool(raw))
+            elif isinstance(cur_val, list) and name == "file_extensions":
+                extensions: List[FileExtensionSetting] = []
+                if isinstance(raw, list):
+                    for item in raw:
+                        try:
+                            ext = FileExtensionSetting.from_any(item)
+                        except ValueError:
+                            continue
+                        existing_keys = {e.key for e in extensions}
+                        base_key = ext.key
+                        suffix = 2
+                        key_candidate = base_key
+                        while key_candidate in existing_keys:
+                            key_candidate = f"{base_key}_{suffix}"
+                            suffix += 1
+                        if key_candidate != ext.key:
+                            ext = FileExtensionSetting(
+                                key=key_candidate,
+                                label=ext.label,
+                                patterns=list(ext.patterns),
+                                enabled=ext.enabled,
+                            )
+                        extensions.append(ext)
+                if not extensions:
+                    extensions = [
+                        FileExtensionSetting(
+                            key=ext.key,
+                            label=ext.label,
+                            patterns=list(ext.patterns),
+                            enabled=legacy_flags.get(ext.key, ext.enabled),
+                        )
+                        for ext in DEFAULT_FILE_EXTENSIONS
+                    ]
+                else:
+                    if legacy_flags:
+                        for ext in extensions:
+                            if ext.key in legacy_flags:
+                                ext.enabled = legacy_flags[ext.key]
+                setattr(inst, name, extensions)
             else:
                 setattr(inst, name, _as_str(raw))
         return inst

--- a/gui.py
+++ b/gui.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 
-from app_settings import AppSettings
+from app_settings import AppSettings, FileExtensionSetting
 from helpers import _to_str, _build_file_index, create_export_bundle, ExportBundleResult
 from models import Supplier, Client, DeliveryAddress
 from suppliers_db import SuppliersDB, SUPPLIERS_DB_FILE
@@ -1036,10 +1036,180 @@ def start_gui():
         def __init__(self, master, app: "App"):
             super().__init__(master)
             self.app = app
-
-            tk.Label(self, text="Instellingen volgen…").pack(
-                fill="both", expand=True, padx=8, pady=8
+            self.extensions: List[FileExtensionSetting] = deepcopy(
+                self.app.settings.file_extensions
             )
+
+            tk.Label(
+                self,
+                text=(
+                    "Beheer hier welke bestandstypen beschikbaar zijn op het hoofdscherm.\n"
+                    "Voeg extensies toe of verwijder ze naar wens."
+                ),
+                justify="left",
+                anchor="w",
+            ).pack(fill="x", padx=8, pady=(8, 4))
+
+            list_container = tk.Frame(self)
+            list_container.pack(fill="both", expand=True, padx=8)
+
+            self.listbox = tk.Listbox(list_container, activestyle="none")
+            self.listbox.pack(side="left", fill="both", expand=True)
+            scrollbar = tk.Scrollbar(list_container, command=self.listbox.yview)
+            scrollbar.pack(side="right", fill="y")
+            self.listbox.configure(yscrollcommand=scrollbar.set)
+            self.listbox.bind("<Double-Button-1>", lambda _e: self._edit_selected())
+
+            btns = tk.Frame(self)
+            btns.pack(fill="x", padx=8, pady=(4, 8))
+            tk.Button(btns, text="Toevoegen", command=self._add_extension).pack(
+                side="left", padx=4
+            )
+            tk.Button(btns, text="Bewerken", command=self._edit_selected).pack(
+                side="left", padx=4
+            )
+            tk.Button(btns, text="Verwijderen", command=self._remove_selected).pack(
+                side="left", padx=4
+            )
+
+            self._refresh_list()
+
+        def _refresh_list(self) -> None:
+            self.listbox.delete(0, tk.END)
+            if not self.extensions:
+                self.listbox.insert(0, "Geen bestandstypen gedefinieerd.")
+                self.listbox.itemconfig(0, foreground="#777777")
+                return
+            for ext in self.extensions:
+                status = "✓" if ext.enabled else "✗"
+                patterns = ", ".join(ext.patterns)
+                self.listbox.insert(tk.END, f"{status} {ext.label} — {patterns}")
+
+        def _selected_index(self) -> Optional[int]:
+            if not self.extensions:
+                return None
+            sel = self.listbox.curselection()
+            if not sel:
+                return None
+            idx = int(sel[0])
+            if idx >= len(self.extensions):
+                return None
+            return idx
+
+        def _selected_extension(self) -> Optional[FileExtensionSetting]:
+            idx = self._selected_index()
+            if idx is None:
+                return None
+            return self.extensions[idx]
+
+        def _ensure_unique_key(self, key: str, exclude_index: Optional[int] = None) -> str:
+            existing = {
+                ext.key
+                for idx, ext in enumerate(self.extensions)
+                if exclude_index is None or idx != exclude_index
+            }
+            if key not in existing:
+                return key
+            base = key
+            suffix = 2
+            while True:
+                candidate = f"{base}_{suffix}"
+                if candidate not in existing:
+                    return candidate
+                suffix += 1
+
+        def _persist(self) -> None:
+            self.app.apply_file_extensions(deepcopy(self.extensions))
+            self.extensions = deepcopy(self.app.settings.file_extensions)
+            self._refresh_list()
+
+        def _add_extension(self) -> None:
+            self._open_extension_dialog("Bestandstype toevoegen", None)
+
+        def _edit_selected(self) -> None:
+            ext = self._selected_extension()
+            if ext is None:
+                return
+            self._open_extension_dialog("Bestandstype bewerken", ext)
+
+        def _remove_selected(self) -> None:
+            idx = self._selected_index()
+            if idx is None:
+                return
+            ext = self.extensions[idx]
+            if not messagebox.askyesno(
+                "Bevestigen",
+                f"Verwijder '{ext.label}' van de lijst?",
+                parent=self,
+            ):
+                return
+            del self.extensions[idx]
+            self._persist()
+
+        def _open_extension_dialog(
+            self, title: str, existing: Optional[FileExtensionSetting]
+        ) -> None:
+            win = tk.Toplevel(self)
+            win.title(title)
+            win.transient(self)
+            win.grab_set()
+
+            tk.Label(win, text="Naam:").grid(row=0, column=0, sticky="e", padx=4, pady=4)
+            name_var = tk.StringVar(value=existing.label if existing else "")
+            tk.Entry(win, textvariable=name_var, width=40).grid(
+                row=0, column=1, padx=4, pady=4
+            )
+
+            tk.Label(win, text="Extensies (komma of spatie gescheiden):").grid(
+                row=1, column=0, sticky="e", padx=4, pady=4
+            )
+            patterns_text = ", ".join(existing.patterns) if existing else ""
+            patterns_var = tk.StringVar(value=patterns_text)
+            tk.Entry(win, textvariable=patterns_var, width=40).grid(
+                row=1, column=1, padx=4, pady=4
+            )
+
+            enabled_var = tk.BooleanVar(value=existing.enabled if existing else True)
+            tk.Checkbutton(
+                win,
+                text="Standaard aangevinkt",
+                variable=enabled_var,
+            ).grid(row=2, column=1, sticky="w", padx=4, pady=4)
+
+            def _save() -> None:
+                try:
+                    new_ext = FileExtensionSetting.from_user_input(
+                        name_var.get(),
+                        patterns_var.get(),
+                        enabled_var.get(),
+                        key=existing.key if existing else None,
+                    )
+                except ValueError as exc:
+                    messagebox.showerror("Fout", str(exc), parent=win)
+                    return
+                if existing is None:
+                    new_ext.key = self._ensure_unique_key(new_ext.key)
+                    self.extensions.append(new_ext)
+                else:
+                    idx = self.extensions.index(existing)
+                    new_ext.key = self._ensure_unique_key(new_ext.key, exclude_index=idx)
+                    self.extensions[idx] = new_ext
+                self._persist()
+                win.destroy()
+
+            btns = tk.Frame(win)
+            btns.grid(row=3, column=0, columnspan=2, pady=(8, 4))
+            tk.Button(btns, text="Opslaan", command=_save).pack(side="left", padx=4)
+            tk.Button(btns, text="Annuleer", command=win.destroy).pack(
+                side="left", padx=4
+            )
+
+            win.columnconfigure(1, weight=1)
+            name_var.set(name_var.get())
+            win.resizable(False, False)
+            win.wait_visibility()
+            win.focus_set()
+            win.wait_window()
 
     class App(tk.Tk):
         def __init__(self):
@@ -1105,6 +1275,7 @@ def start_gui():
             self.delivery_db = DeliveryAddressesDB.load(DELIVERY_DB_FILE)
 
             self.settings = AppSettings.load()
+            self._suspend_save = False
 
             self.source_folder_var = tk.StringVar(
                 master=self, value=self.settings.source_folder
@@ -1118,10 +1289,8 @@ def start_gui():
             self.project_name_var = tk.StringVar(
                 master=self, value=self.settings.project_name
             )
-            self.pdf_var = tk.IntVar(master=self, value=1 if self.settings.pdf else 0)
-            self.step_var = tk.IntVar(master=self, value=1 if self.settings.step else 0)
-            self.dxf_var = tk.IntVar(master=self, value=1 if self.settings.dxf else 0)
-            self.dwg_var = tk.IntVar(master=self, value=1 if self.settings.dwg else 0)
+            self.extension_vars: Dict[str, tk.IntVar] = {}
+            self._sync_extension_vars_from_settings()
             self.zip_var = tk.IntVar(
                 master=self, value=1 if self.settings.zip_per_production else 0
             )
@@ -1165,10 +1334,6 @@ def start_gui():
             ):
                 var.trace_add("write", self._save_settings)
             for var in (
-                self.pdf_var,
-                self.step_var,
-                self.dxf_var,
-                self.dwg_var,
                 self.zip_var,
                 self.export_date_prefix_var,
                 self.export_date_suffix_var,
@@ -1285,25 +1450,14 @@ def start_gui():
             export_name_frame.grid(row=0, column=2, sticky="nsew")
             export_name_frame.grid_columnconfigure(0, weight=1)
 
-            ext_frame = tk.Frame(filt)
-            ext_frame.grid(row=0, column=0, sticky="nw", padx=8, pady=4)
+            self.ext_frame = tk.Frame(filt)
+            self.ext_frame.grid(row=0, column=0, sticky="nw", padx=8, pady=4)
             options_frame = tk.Frame(options_frame_parent)
             options_frame.grid(row=0, column=0, sticky="nw", padx=8, pady=4)
             export_name_inner = tk.Frame(export_name_frame)
             export_name_inner.grid(row=0, column=0, sticky="nw", padx=8, pady=4)
 
-            tk.Checkbutton(ext_frame, text="PDF (.pdf)", variable=self.pdf_var, anchor="w").pack(
-                anchor="w", pady=2
-            )
-            tk.Checkbutton(
-                ext_frame, text="STEP (.step, .stp)", variable=self.step_var, anchor="w"
-            ).pack(anchor="w", pady=2)
-            tk.Checkbutton(ext_frame, text="DXF (.dxf)", variable=self.dxf_var, anchor="w").pack(
-                anchor="w", pady=2
-            )
-            tk.Checkbutton(ext_frame, text="DWG (.dwg)", variable=self.dwg_var, anchor="w").pack(
-                anchor="w", pady=2
-            )
+            self._rebuild_extension_checkbuttons()
             tk.Checkbutton(
                 options_frame,
                 text="Zip per productie",
@@ -1436,16 +1590,14 @@ def start_gui():
                 self.client_combo.set(opts[0])
 
         def _save_settings(self, *_args):
+            if getattr(self, "_suspend_save", False):
+                return
             self.source_folder = self.source_folder_var.get().strip()
             self.dest_folder = self.dest_folder_var.get().strip()
             self.settings.source_folder = self.source_folder
             self.settings.dest_folder = self.dest_folder
             self.settings.project_number = self.project_number_var.get().strip()
             self.settings.project_name = self.project_name_var.get().strip()
-            self.settings.pdf = bool(self.pdf_var.get())
-            self.settings.step = bool(self.step_var.get())
-            self.settings.dxf = bool(self.dxf_var.get())
-            self.settings.dwg = bool(self.dwg_var.get())
             self.settings.zip_per_production = bool(self.zip_var.get())
             self.settings.export_date_prefix = bool(self.export_date_prefix_var.get())
             self.settings.export_date_suffix = bool(self.export_date_suffix_var.get())
@@ -1459,10 +1611,93 @@ def start_gui():
             self.settings.custom_suffix_text = self.export_name_custom_suffix_text.get().strip()
             self.settings.bundle_latest = bool(self.bundle_latest_var.get())
             self.settings.bundle_dry_run = bool(self.bundle_dry_run_var.get())
+            for ext in self.settings.file_extensions:
+                var = self.extension_vars.get(ext.key)
+                if var is not None:
+                    ext.enabled = bool(var.get())
             try:
                 self.settings.save()
             except Exception as exc:
                 print(f"Kon instellingen niet opslaan: {exc}", file=sys.stderr)
+
+        def _sync_extension_vars_from_settings(self) -> None:
+            prev = getattr(self, "_suspend_save", False)
+            self._suspend_save = True
+            new_vars: Dict[str, tk.IntVar] = {}
+            try:
+                for ext in self.settings.file_extensions:
+                    var = self.extension_vars.get(ext.key)
+                    if var is None:
+                        var = tk.IntVar(master=self, value=1 if ext.enabled else 0)
+                        var.trace_add("write", self._save_settings)
+                    else:
+                        desired = 1 if ext.enabled else 0
+                        if var.get() != desired:
+                            var.set(desired)
+                    new_vars[ext.key] = var
+            finally:
+                self._suspend_save = prev
+            self.extension_vars = new_vars
+
+        def _rebuild_extension_checkbuttons(self) -> None:
+            if not hasattr(self, "ext_frame"):
+                return
+            for child in self.ext_frame.winfo_children():
+                child.destroy()
+            if not self.settings.file_extensions:
+                tk.Label(
+                    self.ext_frame,
+                    text="Geen bestandstypen beschikbaar. Voeg ze toe via instellingen.",
+                    anchor="w",
+                    justify="left",
+                ).pack(anchor="w", pady=2)
+                return
+            for ext in self.settings.file_extensions:
+                var = self.extension_vars.get(ext.key)
+                if var is None:
+                    var = tk.IntVar(master=self, value=1 if ext.enabled else 0)
+                    var.trace_add("write", self._save_settings)
+                    self.extension_vars[ext.key] = var
+                tk.Checkbutton(
+                    self.ext_frame, text=ext.label, variable=var, anchor="w"
+                ).pack(anchor="w", pady=2)
+
+        def apply_file_extensions(self, extensions: List[FileExtensionSetting]) -> None:
+            normalized: List[FileExtensionSetting] = []
+            seen_keys = set()
+            for ext in extensions:
+                if isinstance(ext, FileExtensionSetting):
+                    ext_obj = FileExtensionSetting(
+                        key=ext.key,
+                        label=ext.label,
+                        patterns=list(ext.patterns),
+                        enabled=bool(ext.enabled),
+                    )
+                else:
+                    try:
+                        ext_obj = FileExtensionSetting.from_any(ext)
+                    except ValueError:
+                        continue
+                base_key = ext_obj.key or "ext"
+                key = base_key
+                suffix = 2
+                while key in seen_keys:
+                    key = f"{base_key}_{suffix}"
+                    suffix += 1
+                if key != ext_obj.key:
+                    ext_obj = FileExtensionSetting(
+                        key=key,
+                        label=ext_obj.label,
+                        patterns=list(ext_obj.patterns),
+                        enabled=ext_obj.enabled,
+                    )
+                normalized.append(ext_obj)
+                seen_keys.add(key)
+
+            self.settings.file_extensions = normalized
+            self._sync_extension_vars_from_settings()
+            self._rebuild_extension_checkbuttons()
+            self._save_settings()
 
         def _pick_src(self):
             from tkinter import filedialog
@@ -1479,12 +1714,14 @@ def start_gui():
                 self._save_settings()
 
         def _selected_exts(self) -> Optional[List[str]]:
-            exts = []
-            if self.pdf_var.get(): exts.append(".pdf")
-            if self.step_var.get(): exts += [".step",".stp"]
-            if self.dxf_var.get(): exts.append(".dxf")
-            if self.dwg_var.get(): exts.append(".dwg")
-            return exts or None
+            selected: List[str] = []
+            for ext in self.settings.file_extensions:
+                var = self.extension_vars.get(ext.key)
+                if var is None:
+                    continue
+                if var.get():
+                    selected.extend(ext.patterns)
+            return selected or None
 
         def _load_bom_from_path(self, path: str) -> None:
             df = load_bom(path)

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -1,4 +1,6 @@
-from app_settings import AppSettings
+import json
+
+from app_settings import AppSettings, FileExtensionSetting, DEFAULT_FILE_EXTENSIONS
 
 
 def test_app_settings_roundtrip(tmp_path):
@@ -8,10 +10,20 @@ def test_app_settings_roundtrip(tmp_path):
         dest_folder="/tmp/dst",
         project_number="PN-123",
         project_name="Demo",
-        pdf=True,
-        step=True,
-        dxf=False,
-        dwg=True,
+        file_extensions=[
+            FileExtensionSetting(
+                key="pdf",
+                label="PDF (.pdf)",
+                patterns=[".pdf"],
+                enabled=True,
+            ),
+            FileExtensionSetting(
+                key="igs",
+                label="IGES (.iges, .igs)",
+                patterns=[".iges", ".igs"],
+                enabled=False,
+            ),
+        ],
         zip_per_production=False,
         export_date_prefix=True,
         export_date_suffix=False,
@@ -36,3 +48,22 @@ def test_app_settings_corrupt_file_returns_defaults(tmp_path):
     loaded = AppSettings.load(path)
 
     assert loaded == AppSettings()
+
+
+def test_app_settings_loads_legacy_extension_flags(tmp_path):
+    path = tmp_path / "app_settings.json"
+    payload = {
+        "source_folder": "/tmp/src",
+        "pdf": 1,
+        "step": False,
+        "dxf": "true",
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = AppSettings.load(path)
+
+    assert any(ext.key == "pdf" and ext.enabled for ext in loaded.file_extensions)
+    assert any(ext.key == "dxf" and ext.enabled for ext in loaded.file_extensions)
+    assert any(ext.key == "step" and not ext.enabled for ext in loaded.file_extensions)
+    loaded_keys = {ext.key for ext in loaded.file_extensions}
+    assert {ext.key for ext in DEFAULT_FILE_EXTENSIONS}.issubset(loaded_keys)

--- a/tests/test_refresh_options.py
+++ b/tests/test_refresh_options.py
@@ -7,6 +7,7 @@ from suppliers_db import SuppliersDB
 from delivery_addresses_db import DeliveryAddressesDB
 from clients_db import ClientsDB
 from models import Supplier, DeliveryAddress, Client
+from app_settings import FileExtensionSetting
 
 
 class DummyCombo:
@@ -68,6 +69,7 @@ def _load_gui_classes():
         "DeliveryAddress": DeliveryAddress,
         "SuppliersDB": SuppliersDB,
         "DeliveryAddressesDB": DeliveryAddressesDB,
+        "FileExtensionSetting": FileExtensionSetting,
     }
     exec(code, ns)
     return ns["SupplierSelectionFrame"], ns["App"]


### PR DESCRIPTION
## Summary
- add a `FileExtensionSetting` model and persist a configurable `file_extensions` list in `AppSettings`, including migration from legacy boolean flags
- render the main tab’s extension checkboxes dynamically and add a settings tab editor to add, edit or remove file extensions
- extend the test suite to cover the new settings structure and expose `FileExtensionSetting` to GUI extraction tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d3a0cd529c8322874fa065abcae5be