### PR TITLE
Add client logo management and PDF rendering

### DIFF
--- a/clients_db.py
+++ b/clients_db.py
@@ -73,7 +73,9 @@ class ClientsDB:
             cur = self.clients[i]
             for f in asdict(client):
                 val = getattr(client, f)
-                if val not in (None, ""):
+                if f in {"logo_path", "logo_crop"}:
+                    setattr(cur, f, val)
+                elif val not in (None, ""):
                     setattr(cur, f, val)
         else:
             self.clients.append(client)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyPDF2
 pandas
 openpyxl
 tksheet
+Pillow

--- a/tests/test_client_logo.py
+++ b/tests/test_client_logo.py
@@ -1,0 +1,74 @@
+import pytest
+from PIL import Image
+
+from clients_db import ClientsDB
+from models import Client, Supplier
+from orders import generate_pdf_order_platypus, REPORTLAB_OK
+
+
+def test_clients_db_persists_logo_fields(tmp_path):
+    client = Client(
+        name="ACME",
+        logo_path="client_logos/acme.png",
+        logo_crop={"left": 5, "top": 10, "right": 105, "bottom": 210},
+    )
+    db = ClientsDB([client])
+    path = tmp_path / "clients.json"
+    db.save(path)
+
+    loaded = ClientsDB.load(path)
+    assert loaded.clients
+    saved = loaded.clients[0]
+    assert saved.logo_path == "client_logos/acme.png"
+    assert saved.logo_crop == {"left": 5, "top": 10, "right": 105, "bottom": 210}
+
+
+@pytest.mark.skipif(not REPORTLAB_OK, reason="ReportLab niet beschikbaar")
+def test_generate_pdf_order_includes_logo(tmp_path):
+    logo_path = tmp_path / "logo.png"
+    Image.new("RGB", (400, 200), "red").save(logo_path)
+
+    pdf_path = tmp_path / "order.pdf"
+    company = {
+        "name": "ACME",
+        "address": "Example Street 1",
+        "vat": "BE0123456789",
+        "email": "info@example.com",
+        "logo_path": str(logo_path),
+        "logo_crop": {"left": 50, "top": 0, "right": 350, "bottom": 200},
+    }
+    supplier = Supplier(supplier="Supplier BV")
+    items = [
+        {
+            "PartNumber": "PN-1",
+            "Description": "Onderdeel",
+            "Materiaal": "",
+            "Aantal": 1,
+            "Oppervlakte": "",
+            "Gewicht": "",
+        }
+    ]
+
+    generate_pdf_order_platypus(
+        str(pdf_path),
+        company,
+        supplier,
+        production="PROD-1",
+        items=items,
+    )
+
+    from PyPDF2 import PdfReader
+
+    reader = PdfReader(str(pdf_path))
+    page = reader.pages[0]
+    resources = page.get("/Resources")
+    assert resources is not None
+    xobjects = resources.get("/XObject")
+    assert xobjects is not None
+    dims = []
+    for obj in xobjects.values():
+        xobj = obj.get_object()
+        if xobj.get("/Subtype") == "/Image":
+            dims.append((int(xobj.get("/Width")), int(xobj.get("/Height"))))
+    assert dims
+    assert (300, 200) in dims


### PR DESCRIPTION
## Summary
- add optional logo path/crop handling to clients, persisting the data in the JSON database
- extend the client manager dialog with logo upload, preview, and crop tooling backed by Pillow
- render cropped logos in generated order PDFs and cover the new behaviour with tests
- declare Pillow as a dependency for the new imaging features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68d65f112b808322836c53698606bb77