### PR TITLE
Install ReportLab dependency and fix PDF header layout

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -295,10 +295,7 @@ def generate_pdf_order_platypus(
         )
         return stacked
 
-    if KeepTogether and len(left_elements) > 1:
-        left_cell = KeepTogether(left_elements)
-    else:
-        left_cell = _stack_left_elements(left_elements)
+    left_cell = _stack_left_elements(left_elements)
 
     right_lines: List[str] = []
     if delivery:
@@ -316,7 +313,7 @@ def generate_pdf_order_platypus(
     if doc_lines:
         story.append(Paragraph("<br/>".join(doc_lines), text_style))
     story.append(Spacer(0, 6))
-    header_tbl = LongTable(
+    header_tbl = Table(
         [
             [
                 left_cell,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 openpyxl
 tksheet
 Pillow
+reportlab


### PR DESCRIPTION
## Summary
- add the ReportLab package to the runtime requirements so PDF generation dependencies are installed
- adjust the order PDF header flowables to avoid KeepTogether overflows when ReportLab is present

## Testing
- pip install -r requirements.txt
- pytest tests/test_client_logo.py::test_generate_pdf_order_includes_logo -q

------
https://chatgpt.com/codex/tasks/task_b_68d6737098548322bea7edd54c453fb6