### PR TITLE
Ensure GUI uses shared client logo directory

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -27,10 +27,7 @@ from orders import (
     combine_pdfs_from_source,
     _prefix_for_doc_type,
 )
-from logo_resolver import resolve_logo_path as shared_resolve_logo_path
-
-
-CLIENT_LOGO_DIR = Path("client_logos")
+from logo_resolver import CLIENT_LOGO_DIR, resolve_logo_path as shared_resolve_logo_path
 
 
 def _norm(text: str) -> str:
@@ -220,7 +217,7 @@ def start_gui():
                 if not path:
                     return
                 dest_dir = CLIENT_LOGO_DIR
-                dest_dir.mkdir(exist_ok=True)
+                dest_dir.mkdir(parents=True, exist_ok=True)
                 ext = Path(path).suffix or ".png"
                 base = entries["name"].get().strip() or Path(path).stem
                 safe = re.sub(r"[^a-z0-9]+", "_", base.lower()).strip("_") or "logo"

--- a/tests/test_client_logo.py
+++ b/tests/test_client_logo.py
@@ -13,9 +13,10 @@ import logo_resolver
 
 
 def test_clients_db_persists_logo_fields(tmp_path):
+    stored_logo_path = f"{logo_resolver.CLIENT_LOGO_DIR.name}/acme.png"
     client = Client(
         name="ACME",
-        logo_path="client_logos/acme.png",
+        logo_path=stored_logo_path,
         logo_crop={"left": 5, "top": 10, "right": 105, "bottom": 210},
     )
     db = ClientsDB([client])
@@ -25,7 +26,7 @@ def test_clients_db_persists_logo_fields(tmp_path):
     loaded = ClientsDB.load(path)
     assert loaded.clients
     saved = loaded.clients[0]
-    assert saved.logo_path == "client_logos/acme.png"
+    assert saved.logo_path == stored_logo_path
     assert saved.logo_crop == {"left": 5, "top": 10, "right": 105, "bottom": 210}
 
 
@@ -82,12 +83,12 @@ def test_generate_pdf_order_includes_logo(tmp_path):
 
 @pytest.mark.skipif(not REPORTLAB_OK, reason="ReportLab niet beschikbaar")
 def test_generate_pdf_order_logo_resolves_after_chdir(tmp_path, monkeypatch):
-    logo_dir = tmp_path / "client_logos"
+    logo_dir = (tmp_path / "shared_logos").resolve()
     logo_dir.mkdir()
-    logo_path = logo_dir / "temp.png"
-    Image.new("RGB", (160, 80), "blue").save(logo_path)
-
     monkeypatch.setattr(logo_resolver, "CLIENT_LOGO_DIR", logo_dir)
+
+    logo_path = logo_resolver.CLIENT_LOGO_DIR / "temp.png"
+    Image.new("RGB", (160, 80), "blue").save(logo_path)
 
     work_dir = tmp_path / "elsewhere"
     work_dir.mkdir()
@@ -99,7 +100,7 @@ def test_generate_pdf_order_logo_resolves_after_chdir(tmp_path, monkeypatch):
         "address": "Example Street 1",
         "vat": "BE0123456789",
         "email": "info@example.com",
-        "logo_path": "client_logos/temp.png",
+        "logo_path": f"{logo_resolver.CLIENT_LOGO_DIR.name}/{logo_path.name}",
     }
     supplier = Supplier(supplier="Supplier BV")
     items = [


### PR DESCRIPTION
## Summary
- update the client logo upload workflow to write into the shared CLIENT_LOGO_DIR from logo_resolver
- adjust client logo related tests to rely on the shared directory constant instead of assuming a cwd-relative folder

## Testing
- pytest tests/test_client_logo.py

------
https://chatgpt.com/codex/tasks/task_b_68d68498bdd48322b81ba360d7c725ca