### PR TITLE
Handle missing ReportLab dependency for PDF orders

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -26,6 +26,7 @@ from orders import (
     combine_pdfs_per_production,
     combine_pdfs_from_source,
     _prefix_for_doc_type,
+    ReportLabUnavailableError,
 )
 from logo_resolver import CLIENT_LOGO_DIR, resolve_logo_path as shared_resolve_logo_path
 
@@ -2757,29 +2758,46 @@ def start_gui():
                         else:
                             addr = self.delivery_db.get(clean)
                             resolved_delivery_map[prod] = addr
-                    cnt, chosen = copy_per_production_and_orders(
-                        self.source_folder,
-                        bundle_dest,
-                        current_bom,
-                        exts,
-                        self.db,
-                        sel_map,
-                        doc_map,
-                        doc_num_map,
-                    remember,
-                    client=client,
-                    delivery_map=resolved_delivery_map,
-                    footer_note=self.footer_note_var.get(),
-                    zip_parts=bool(self.zip_var.get()),
-                    date_prefix_exports=bool(self.export_date_prefix_var.get()),
-                    date_suffix_exports=bool(self.export_date_suffix_var.get()),
-                    project_number=project_number,
-                    project_name=project_name,
-                        export_name_prefix_text=token_prefix_text,
-                        export_name_prefix_enabled=token_prefix_enabled,
-                        export_name_suffix_text=token_suffix_text,
-                        export_name_suffix_enabled=token_suffix_enabled,
-                    )
+                    try:
+                        cnt, chosen = copy_per_production_and_orders(
+                            self.source_folder,
+                            bundle_dest,
+                            current_bom,
+                            exts,
+                            self.db,
+                            sel_map,
+                            doc_map,
+                            doc_num_map,
+                            remember_defaults=remember,
+                            client=client,
+                            delivery_map=resolved_delivery_map,
+                            footer_note=self.footer_note_var.get(),
+                            zip_parts=bool(self.zip_var.get()),
+                            date_prefix_exports=bool(self.export_date_prefix_var.get()),
+                            date_suffix_exports=bool(self.export_date_suffix_var.get()),
+                            project_number=project_number,
+                            project_name=project_name,
+                            export_name_prefix_text=token_prefix_text,
+                            export_name_prefix_enabled=token_prefix_enabled,
+                            export_name_suffix_text=token_suffix_text,
+                            export_name_suffix_enabled=token_suffix_enabled,
+                        )
+                    except ReportLabUnavailableError as exc:
+                        def on_missing() -> None:
+                            details = str(exc)
+                            messagebox.showwarning(
+                                "ReportLab vereist",
+                                "ReportLab is nodig om PDF-bestelbonnen te maken.\n"
+                                "Installeer het pakket met:\n  pip install reportlab\n"
+                                f"Details: {details}",
+                                parent=self,
+                            )
+                            self.status_var.set(
+                                "Installatie van ReportLab vereist voor PDF-bestelbonnen."
+                            )
+
+                        self.after(0, on_missing)
+                        return
 
                     def on_done():
                         self.status_var.set(

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -1,10 +1,12 @@
 import os
 import pandas as pd
+import pytest
 from models import Supplier
 from suppliers_db import SuppliersDB
-from orders import copy_per_production_and_orders
+from orders import copy_per_production_and_orders, REPORTLAB_OK
 
 
+@pytest.mark.skipif(not REPORTLAB_OK, reason="ReportLab is vereist voor deze test")
 def test_defaults_persist(tmp_path, monkeypatch):
     # Ensure suppliers DB file is created inside temporary directory
     monkeypatch.chdir(tmp_path)

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -10,9 +10,18 @@ from PyPDF2 import PdfReader
 
 from models import Supplier
 from suppliers_db import SuppliersDB
-from orders import copy_per_production_and_orders, _prefix_for_doc_type
+from orders import (
+    copy_per_production_and_orders,
+    _prefix_for_doc_type,
+    REPORTLAB_OK,
+)
+
+requires_reportlab = pytest.mark.skipif(
+    not REPORTLAB_OK, reason="ReportLab is vereist voor PDF-testen"
+)
 
 
+@requires_reportlab
 def test_doc_number_in_name_and_header(tmp_path):
     reportlab = pytest.importorskip("reportlab")
 
@@ -70,6 +79,7 @@ def test_prefix_helper():
     assert _prefix_for_doc_type("Onbekend") == ""
 
 
+@requires_reportlab
 def test_offerte_prefix_in_output(tmp_path):
     reportlab = pytest.importorskip("reportlab")
 
@@ -122,6 +132,7 @@ def test_offerte_prefix_in_output(tmp_path):
     assert "OFF-42" not in lines[0]
 
 
+@requires_reportlab
 def test_missing_doc_number_omits_prefix_and_header(tmp_path):
     reportlab = pytest.importorskip("reportlab")
 
@@ -171,6 +182,7 @@ def test_missing_doc_number_omits_prefix_and_header(tmp_path):
     assert f"Datum: {today}" in text
 
 
+@requires_reportlab
 def test_doc_number_applied_to_zip_filename(tmp_path):
     db = SuppliersDB()
     db.upsert(Supplier.from_any({"supplier": "ACME"}))

--- a/tests/test_export_dedup.py
+++ b/tests/test_export_dedup.py
@@ -1,9 +1,11 @@
 import zipfile
 
+import pytest
+
 import pandas as pd
 
 from models import Supplier
-from orders import copy_per_production_and_orders
+from orders import copy_per_production_and_orders, REPORTLAB_OK
 from suppliers_db import SuppliersDB
 
 
@@ -20,6 +22,7 @@ def _build_bom() -> pd.DataFrame:
     ])
 
 
+@pytest.mark.skipif(not REPORTLAB_OK, reason="ReportLab is vereist voor deze test")
 def test_duplicate_parts_single_export(tmp_path):
     src = tmp_path / "src"
     dest = tmp_path / "dest"

--- a/tests/test_export_name_token.py
+++ b/tests/test_export_name_token.py
@@ -10,8 +10,12 @@ from cli import build_parser, cli_copy_per_prod
 from clients_db import ClientsDB
 from delivery_addresses_db import DeliveryAddressesDB
 from models import Supplier
-from orders import copy_per_production_and_orders
+from orders import copy_per_production_and_orders, REPORTLAB_OK
 from suppliers_db import SuppliersDB
+
+requires_reportlab = pytest.mark.skipif(
+    not REPORTLAB_OK, reason="ReportLab is vereist voor PDF-exporttests"
+)
 
 
 def _make_db() -> SuppliersDB:
@@ -34,6 +38,7 @@ def _build_bom() -> pd.DataFrame:
         (True, True, "REV-A-PN1-REV-A.pdf"),
     ],
 )
+@requires_reportlab
 def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected):
     monkeypatch.setattr(orders, "SUPPLIERS_DB_FILE", str(tmp_path / "suppliers.json"))
 
@@ -99,6 +104,7 @@ def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected)
             assert info.compress_type == zipfile.ZIP_STORED
 
 
+@requires_reportlab
 def test_export_token_disabled(tmp_path, monkeypatch):
     monkeypatch.setattr(orders, "SUPPLIERS_DB_FILE", str(tmp_path / "suppliers.json"))
 

--- a/tests/test_pdf_missing_dependency.py
+++ b/tests/test_pdf_missing_dependency.py
@@ -1,0 +1,48 @@
+import importlib
+
+import pytest
+
+from models import DeliveryAddress, Supplier
+
+
+def test_generate_pdf_order_requires_reportlab(monkeypatch, tmp_path):
+    orders_module = importlib.import_module("orders")
+    orders_module = importlib.reload(orders_module)
+
+    monkeypatch.setattr(orders_module, "REPORTLAB_OK", False, raising=False)
+
+    out_path = tmp_path / "order.pdf"
+
+    with pytest.raises(orders_module.ReportLabUnavailableError) as excinfo:
+        orders_module.generate_pdf_order_platypus(
+            str(out_path),
+            {
+                "name": "ACME Corp",
+                "address": "Main Street 1",
+                "vat": "BE0123456789",
+                "email": "info@example.com",
+            },
+            Supplier(
+                supplier="Supplier",
+                adres_1="Street 12",
+                postcode="1000",
+                gemeente="Brussels",
+            ),
+            "PROD-1",
+            [
+                {
+                    "PartNumber": "PN-1",
+                    "Description": "Panel",
+                    "Materiaal": "Steel",
+                    "Aantal": "2",
+                    "Oppervlakte": "1.5",
+                    "Gewicht": "3.0",
+                }
+            ],
+            delivery=DeliveryAddress(name="Site", address="Warehouse", remarks="Dock 5"),
+        )
+
+    assert "ReportLab" in str(excinfo.value)
+    assert not out_path.exists()
+
+    importlib.reload(orders_module)


### PR DESCRIPTION
## Summary
- raise a dedicated error when ReportLab is unavailable and ensure PDF generation stops instead of silently returning
- surface actionable ReportLab installation guidance in the CLI and GUI flows that rely on PDF creation
- cover the regression by forcing ReportLab off in tests and skip existing PDF-heavy tests when the dependency is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d687c08fd883229c98651004ed91fa