### PR TITLE
Handle missing Excel logo dependencies gracefully

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -420,7 +420,7 @@ def cli_copy_per_prod(args):
     settings_note = settings.footer_note
     footer_note = settings_note if args.note is None else args.note
 
-    cnt, chosen = copy_per_production_and_orders(
+    cnt, chosen, order_warnings = copy_per_production_and_orders(
         args.source,
         bundle.bundle_dir,
         df,
@@ -443,6 +443,8 @@ def cli_copy_per_prod(args):
     print("Gekopieerd:", cnt)
     for k, v in chosen.items():
         print(f"  {k} → {v}")
+    for warn in order_warnings:
+        print(f"[WAARSCHUWING] {warn}")
     return 0
 
 

--- a/gui.py
+++ b/gui.py
@@ -2757,7 +2757,7 @@ def start_gui():
                         else:
                             addr = self.delivery_db.get(clean)
                             resolved_delivery_map[prod] = addr
-                    cnt, chosen = copy_per_production_and_orders(
+                    cnt, chosen, order_warnings = copy_per_production_and_orders(
                         self.source_folder,
                         bundle_dest,
                         current_bom,
@@ -2766,15 +2766,15 @@ def start_gui():
                         sel_map,
                         doc_map,
                         doc_num_map,
-                    remember,
-                    client=client,
-                    delivery_map=resolved_delivery_map,
-                    footer_note=self.footer_note_var.get(),
-                    zip_parts=bool(self.zip_var.get()),
-                    date_prefix_exports=bool(self.export_date_prefix_var.get()),
-                    date_suffix_exports=bool(self.export_date_suffix_var.get()),
-                    project_number=project_number,
-                    project_name=project_name,
+                        remember,
+                        client=client,
+                        delivery_map=resolved_delivery_map,
+                        footer_note=self.footer_note_var.get(),
+                        zip_parts=bool(self.zip_var.get()),
+                        date_prefix_exports=bool(self.export_date_prefix_var.get()),
+                        date_suffix_exports=bool(self.export_date_suffix_var.get()),
+                        project_number=project_number,
+                        project_name=project_name,
                         export_name_prefix_text=token_prefix_text,
                         export_name_prefix_enabled=token_prefix_enabled,
                         export_name_suffix_text=token_suffix_text,
@@ -2782,13 +2782,24 @@ def start_gui():
                     )
 
                     def on_done():
+                        warn_suffix = (
+                            f" ({len(order_warnings)} waarschuwing(en))"
+                            if order_warnings
+                            else ""
+                        )
                         self.status_var.set(
-                            f"Klaar. Gekopieerd: {cnt}. Leveranciers: {chosen}. → {bundle_dest}"
+                            f"Klaar. Gekopieerd: {cnt}. Leveranciers: {chosen}. → {bundle_dest}{warn_suffix}"
                         )
                         info_lines = ["Bestelbonnen aangemaakt in:", bundle_dest]
                         if bundle.latest_symlink:
                             info_lines.append(f"Symlink: {bundle.latest_symlink}")
                         messagebox.showinfo("Klaar", "\n".join(info_lines), parent=self)
+                        if order_warnings:
+                            messagebox.showwarning(
+                                "Let op",
+                                "\n".join(order_warnings),
+                                parent=self,
+                            )
                         try:
                             if sys.platform.startswith("win"):
                                 os.startfile(bundle_dest)

--- a/tests/self_test.py
+++ b/tests/self_test.py
@@ -75,7 +75,7 @@ def run_tests() -> int:
         df.to_excel(bom, index=False, engine="openpyxl")
         ldf = load_bom(bom)
         assert ldf["Aantal"].max() <= 999  # capped
-        cnt, chosen = copy_per_production_and_orders(
+        cnt, chosen, order_warnings = copy_per_production_and_orders(
             src,
             dst,
             ldf,
@@ -91,6 +91,7 @@ def run_tests() -> int:
         )
         assert cnt == 2
         assert chosen.get("Laser") == "ACME"
+        assert not order_warnings
         prod_folder = os.path.join(dst, "Laser")
         assert os.path.exists(os.path.join(prod_folder, "PN1.pdf"))
         assert os.path.exists(os.path.join(prod_folder, "PN1.stp"))
@@ -125,7 +126,7 @@ def run_tests() -> int:
 
         dst_dates = os.path.join(td, "dst_dates")
         os.makedirs(dst_dates)
-        cnt_dates, _ = copy_per_production_and_orders(
+        cnt_dates, _, _ = copy_per_production_and_orders(
             src,
             dst_dates,
             ldf,
@@ -150,7 +151,7 @@ def run_tests() -> int:
 
         dst_prefix = os.path.join(td, "dst_prefix")
         os.makedirs(dst_prefix)
-        cnt_prefix, _ = copy_per_production_and_orders(
+        cnt_prefix, _, _ = copy_per_production_and_orders(
             src,
             dst_prefix,
             ldf,
@@ -174,7 +175,7 @@ def run_tests() -> int:
 
         dst_prefix_suffix = os.path.join(td, "dst_prefix_suffix")
         os.makedirs(dst_prefix_suffix)
-        cnt_prefix_suffix, _ = copy_per_production_and_orders(
+        cnt_prefix_suffix, _, _ = copy_per_production_and_orders(
             src,
             dst_prefix_suffix,
             ldf,
@@ -221,7 +222,8 @@ def test_order_excel_partnumber_wrap_text(tmp_path):
             "Gewicht": "4,56",
         }
     ]
-    write_order_excel(str(path), items, doc_number="BB-1")
+    warnings = write_order_excel(str(path), items, doc_number="BB-1")
+    assert not warnings
     wb = openpyxl.load_workbook(path)
     ws = wb.active
     header_row = None

--- a/tests/test_cli_delivery_parsing.py
+++ b/tests/test_cli_delivery_parsing.py
@@ -41,7 +41,7 @@ def test_cli_delivery_parsing(monkeypatch, tmp_path):
 
     def fake_copy(*args, **kwargs):
         captured.update(kwargs)
-        return 0, {}
+        return 0, {}, []
 
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)
@@ -93,7 +93,7 @@ def test_cli_delivery_special_tokens(monkeypatch, tmp_path):
 
     def fake_copy(*args, **kwargs):
         captured.update(kwargs)
-        return 0, {}
+        return 0, {}, []
 
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)

--- a/tests/test_cli_doc_options.py
+++ b/tests/test_cli_doc_options.py
@@ -38,7 +38,7 @@ def test_cli_doc_options_parsing(monkeypatch, tmp_path):
 
     def fake_copy(*args, **kwargs):
         captured.update(kwargs)
-        return 0, {}
+        return 0, {}, []
 
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)

--- a/tests/test_defaults_persist.py
+++ b/tests/test_defaults_persist.py
@@ -32,7 +32,7 @@ def test_defaults_persist(tmp_path, monkeypatch):
     overrides = {"Laser": "ACME", "Plasma": "BETA"}
 
     # Run the copy and order generation, remembering defaults
-    cnt, chosen = copy_per_production_and_orders(
+    cnt, chosen, warnings = copy_per_production_and_orders(
         str(src),
         str(dst),
         bom_df,
@@ -48,6 +48,7 @@ def test_defaults_persist(tmp_path, monkeypatch):
 
     assert cnt == 2
     assert chosen == overrides
+    assert not warnings
 
     # Defaults should be updated in memory
     assert db.defaults_by_production == overrides

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -188,7 +188,7 @@ def test_doc_number_applied_to_zip_filename(tmp_path):
 
     doc_num_map = {"Laser": "123"}
 
-    cnt, _ = copy_per_production_and_orders(
+    cnt, _, _ = copy_per_production_and_orders(
         str(src),
         str(dst),
         bom_df,

--- a/tests/test_export_dedup.py
+++ b/tests/test_export_dedup.py
@@ -33,7 +33,7 @@ def test_duplicate_parts_single_export(tmp_path):
     db = _make_db()
     bom_df = _build_bom()
 
-    cnt, _ = copy_per_production_and_orders(
+    cnt, _, _ = copy_per_production_and_orders(
         str(src),
         str(dest),
         bom_df,
@@ -48,7 +48,7 @@ def test_duplicate_parts_single_export(tmp_path):
     exported_files = list((dest / "Laser").glob("PN1*.pdf"))
     assert len(exported_files) == 1
 
-    cnt_zip, _ = copy_per_production_and_orders(
+    cnt_zip, _, _ = copy_per_production_and_orders(
         str(src),
         str(dest_zip),
         bom_df,

--- a/tests/test_export_name_token.py
+++ b/tests/test_export_name_token.py
@@ -49,7 +49,7 @@ def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected)
     db = _make_db()
     bom_df = _build_bom()
 
-    cnt, _ = copy_per_production_and_orders(
+    cnt, _, _ = copy_per_production_and_orders(
         str(src),
         str(dest),
         bom_df,
@@ -68,7 +68,7 @@ def test_export_token_positions(tmp_path, monkeypatch, prefix, suffix, expected)
     exported = dest / "Laser" / expected
     assert exported.exists()
 
-    cnt_zip, _ = copy_per_production_and_orders(
+    cnt_zip, _, _ = copy_per_production_and_orders(
         str(src),
         str(dest_zip),
         bom_df,
@@ -111,7 +111,7 @@ def test_export_token_disabled(tmp_path, monkeypatch):
     db = _make_db()
     bom_df = _build_bom()
 
-    cnt, _ = copy_per_production_and_orders(
+    cnt, _, _ = copy_per_production_and_orders(
         str(src),
         str(dest),
         bom_df,
@@ -166,7 +166,7 @@ def test_cli_export_token_flags(monkeypatch, tmp_path):
 
     def fake_copy(*args, **kwargs):
         captured.update(kwargs)
-        return 0, {}
+        return 0, {}, []
 
     monkeypatch.setattr(cli, "copy_per_production_and_orders", fake_copy)
     cli_copy_per_prod(args)

--- a/tests/test_project_info_output.py
+++ b/tests/test_project_info_output.py
@@ -107,7 +107,7 @@ def test_documents_created_without_suppliers(tmp_path, monkeypatch):
         ]
     )
 
-    cnt, chosen = copy_per_production_and_orders(
+    cnt, chosen, warnings = copy_per_production_and_orders(
         str(src),
         str(dest),
         bom_df,
@@ -123,6 +123,7 @@ def test_documents_created_without_suppliers(tmp_path, monkeypatch):
 
     assert cnt == 1
     assert chosen == {"Laser": ""}
+    assert not warnings
 
     today = datetime.date.today().strftime("%Y-%m-%d")
     prod_folder = dest / "Laser"


### PR DESCRIPTION
## Summary
- add explicit warnings when `write_order_excel` cannot embed a logo because Pillow/openpyxl image support is missing and propagate them to callers
- surface propagated order warnings in the CLI output and GUI status so users notice skipped logos
- cover the new warning flow with tests, including a regression that simulates missing image support

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d687d0d33c8322a9578839c07cdc95