### PR TITLE
Handle missing ReportLab during order export

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -673,6 +673,12 @@ def copy_per_production_and_orders(
     count_copied = 0
     chosen: Dict[str, str] = {}
     warnings: List[str] = []
+    pdf_generation_enabled = REPORTLAB_OK
+    if not pdf_generation_enabled:
+        warnings.append(
+            "PDF-export overgeslagen: ReportLab niet beschikbaar. "
+            "Installeer het 'reportlab'-pakket om PDF-bestanden te genereren."
+        )
     doc_type_map = doc_type_map or {}
     doc_num_map = doc_num_map or {}
 
@@ -837,25 +843,29 @@ def copy_per_production_and_orders(
             )
         )
 
-        pdf_path = os.path.join(
-            prod_folder, f"{doc_type}{num_part}_{prod}_{today}.pdf"
-        )
-        try:
-            generate_pdf_order_platypus(
-                pdf_path,
-                company,
-                supplier,
-                prod,
-                items,
-                doc_type=doc_type,
-                doc_number=doc_num or None,
-                footer_note=footer_note_text,
-                delivery=delivery,
-                project_number=project_number,
-                project_name=project_name,
+        if pdf_generation_enabled:
+            pdf_path = os.path.join(
+                prod_folder, f"{doc_type}{num_part}_{prod}_{today}.pdf"
             )
-        except Exception as e:
-            print(f"[WAARSCHUWING] PDF mislukt voor {prod}: {e}", file=sys.stderr)
+            try:
+                generate_pdf_order_platypus(
+                    pdf_path,
+                    company,
+                    supplier,
+                    prod,
+                    items,
+                    doc_type=doc_type,
+                    doc_number=doc_num or None,
+                    footer_note=footer_note_text,
+                    delivery=delivery,
+                    project_number=project_number,
+                    project_name=project_name,
+                )
+            except Exception as e:
+                print(
+                    f"[WAARSCHUWING] PDF mislukt voor {prod}: {e}",
+                    file=sys.stderr,
+                )
 
     # Persist any (possibly unchanged) supplier defaults so that callers can rely on
     # the database reflecting the latest state on disk.

--- a/tests/test_pdf_reportlab_unavailable.py
+++ b/tests/test_pdf_reportlab_unavailable.py
@@ -1,0 +1,67 @@
+import datetime
+import pandas as pd
+
+from models import Supplier
+from suppliers_db import SuppliersDB
+import orders
+
+
+def test_pdf_export_skipped_when_reportlab_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    db = SuppliersDB()
+    db.upsert(Supplier.from_any({"supplier": "ACME"}))
+
+    source = tmp_path / "src"
+    dest = tmp_path / "dest"
+    source.mkdir()
+    dest.mkdir()
+
+    (source / "PN1.pdf").write_text("dummy")
+
+    bom_df = pd.DataFrame(
+        [
+            {
+                "PartNumber": "PN1",
+                "Description": "onderdeel",
+                "Production": "Laser",
+                "Aantal": 1,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(orders, "REPORTLAB_OK", False, raising=False)
+
+    def _unexpected_pdf_call(*_args, **_kwargs):  # pragma: no cover - safety guard
+        raise AssertionError("PDF helper should not be called when ReportLab is absent")
+
+    monkeypatch.setattr(orders, "generate_pdf_order_platypus", _unexpected_pdf_call)
+
+    count, chosen, warnings = orders.copy_per_production_and_orders(
+        str(source),
+        str(dest),
+        bom_df,
+        [".pdf"],
+        db,
+        {"Laser": "ACME"},
+        doc_type_map={},
+        doc_num_map={},
+        remember_defaults=False,
+        client=None,
+        delivery_map={},
+    )
+
+    assert count == 1
+    assert chosen == {"Laser": "ACME"}
+    assert any("ReportLab" in warn for warn in warnings)
+
+    today = datetime.date.today().strftime("%Y-%m-%d")
+    prod_dir = dest / "Laser"
+    excel_path = prod_dir / f"Bestelbon_Laser_{today}.xlsx"
+    pdf_path = prod_dir / f"Bestelbon_Laser_{today}.pdf"
+
+    assert excel_path.exists()
+    assert not pdf_path.exists()
+
+    exported_files = {p.name for p in prod_dir.iterdir()}
+    assert "PN1.pdf" in exported_files


### PR DESCRIPTION
## Summary
- skip PDF generation when ReportLab is unavailable and emit a clear warning that propagates to the CLI and GUI
- add a regression test covering the missing ReportLab scenario to ensure exports continue to succeed

## Testing
- pytest tests/test_pdf_reportlab_unavailable.py

------
https://chatgpt.com/codex/tasks/task_b_68d68cfe9004832292a599ab51c72e4a