### PR TITLE
Raise explicit error when ReportLab is unavailable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,6 +4,7 @@
 """Command-line interface helpers for Filehopper."""
 
 import os
+import sys
 import shutil
 import argparse
 from typing import Iterable, List, Optional, Union
@@ -23,7 +24,11 @@ from suppliers_db import SuppliersDB, SUPPLIERS_DB_FILE
 from clients_db import ClientsDB, CLIENTS_DB_FILE
 from delivery_addresses_db import DeliveryAddressesDB, DELIVERY_DB_FILE
 from bom import read_csv_flex, load_bom
-from orders import copy_per_production_and_orders, DEFAULT_FOOTER_NOTE
+from orders import (
+    copy_per_production_and_orders,
+    DEFAULT_FOOTER_NOTE,
+    PDFGenerationUnavailableError,
+)
 from app_settings import AppSettings
 
 DEFAULT_ALLOWED_EXTS = "pdf,dxf,dwg,step,stp"
@@ -420,31 +425,36 @@ def cli_copy_per_prod(args):
     settings_note = settings.footer_note
     footer_note = settings_note if args.note is None else args.note
 
-    cnt, chosen, order_warnings = copy_per_production_and_orders(
-        args.source,
-        bundle.bundle_dir,
-        df,
-        exts,
-        db,
-        override_map,
-        doc_type_map=doc_type_map,
-        doc_num_map=doc_num_map,
-        remember_defaults=args.remember_defaults,
-        client=client,
-        delivery_map=delivery_map,
-        footer_note=footer_note if footer_note is not None else DEFAULT_FOOTER_NOTE,
-        project_number=args.project_number,
-        project_name=args.project_name,
-        export_name_prefix_text=export_prefix_text,
-        export_name_prefix_enabled=export_prefix_enabled,
-        export_name_suffix_text=export_suffix_text,
-        export_name_suffix_enabled=export_suffix_enabled,
-    )
+    try:
+        cnt, chosen, order_warnings = copy_per_production_and_orders(
+            args.source,
+            bundle.bundle_dir,
+            df,
+            exts,
+            db,
+            override_map,
+            doc_type_map=doc_type_map,
+            doc_num_map=doc_num_map,
+            remember_defaults=args.remember_defaults,
+            client=client,
+            delivery_map=delivery_map,
+            footer_note=footer_note if footer_note is not None else DEFAULT_FOOTER_NOTE,
+            project_number=args.project_number,
+            project_name=args.project_name,
+            export_name_prefix_text=export_prefix_text,
+            export_name_prefix_enabled=export_prefix_enabled,
+            export_name_suffix_text=export_suffix_text,
+            export_name_suffix_enabled=export_suffix_enabled,
+        )
+    except PDFGenerationUnavailableError as exc:
+        warning = str(exc)
+        print(f"[WAARSCHUWING] {warning}", file=sys.stderr)
+        cnt, chosen, order_warnings = 0, {}, [warning]
     print("Gekopieerd:", cnt)
     for k, v in chosen.items():
         print(f"  {k} → {v}")
     for warn in order_warnings:
-        print(f"[WAARSCHUWING] {warn}")
+        print(f"[WAARSCHUWING] {warn}", file=sys.stderr)
     return 0
 
 

--- a/gui.py
+++ b/gui.py
@@ -26,6 +26,7 @@ from orders import (
     combine_pdfs_per_production,
     combine_pdfs_from_source,
     _prefix_for_doc_type,
+    PDFGenerationUnavailableError,
 )
 from logo_resolver import CLIENT_LOGO_DIR, resolve_logo_path as shared_resolve_logo_path
 
@@ -2757,29 +2758,32 @@ def start_gui():
                         else:
                             addr = self.delivery_db.get(clean)
                             resolved_delivery_map[prod] = addr
-                    cnt, chosen, order_warnings = copy_per_production_and_orders(
-                        self.source_folder,
-                        bundle_dest,
-                        current_bom,
-                        exts,
-                        self.db,
-                        sel_map,
-                        doc_map,
-                        doc_num_map,
-                        remember,
-                        client=client,
-                        delivery_map=resolved_delivery_map,
-                        footer_note=self.footer_note_var.get(),
-                        zip_parts=bool(self.zip_var.get()),
-                        date_prefix_exports=bool(self.export_date_prefix_var.get()),
-                        date_suffix_exports=bool(self.export_date_suffix_var.get()),
-                        project_number=project_number,
-                        project_name=project_name,
-                        export_name_prefix_text=token_prefix_text,
-                        export_name_prefix_enabled=token_prefix_enabled,
-                        export_name_suffix_text=token_suffix_text,
-                        export_name_suffix_enabled=token_suffix_enabled,
-                    )
+                    try:
+                        cnt, chosen, order_warnings = copy_per_production_and_orders(
+                            self.source_folder,
+                            bundle_dest,
+                            current_bom,
+                            exts,
+                            self.db,
+                            sel_map,
+                            doc_map,
+                            doc_num_map,
+                            remember,
+                            client=client,
+                            delivery_map=resolved_delivery_map,
+                            footer_note=self.footer_note_var.get(),
+                            zip_parts=bool(self.zip_var.get()),
+                            date_prefix_exports=bool(self.export_date_prefix_var.get()),
+                            date_suffix_exports=bool(self.export_date_suffix_var.get()),
+                            project_number=project_number,
+                            project_name=project_name,
+                            export_name_prefix_text=token_prefix_text,
+                            export_name_prefix_enabled=token_prefix_enabled,
+                            export_name_suffix_text=token_suffix_text,
+                            export_name_suffix_enabled=token_suffix_enabled,
+                        )
+                    except PDFGenerationUnavailableError as exc:
+                        cnt, chosen, order_warnings = 0, {}, [str(exc)]
 
                     def on_done():
                         warn_suffix = (


### PR DESCRIPTION
## Summary
- raise a dedicated PDFGenerationUnavailableError when ReportLab is not installed
- surface the dependency warning through CLI and GUI export workflows
- add a regression test to ensure the warning is emitted when ReportLab support is absent

## Testing
- pytest tests/test_pdf_reportlab_unavailable.py

------
https://chatgpt.com/codex/tasks/task_b_68d68f7cd03c83229560a34d711540fa