### PR TITLE
Add PyInstaller build tooling for macOS and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,38 @@ pip install tksheet
 
 Start vervolgens de applicatie met `python main.py` of `python -m gui`.
 
+## Zelfstandige executables bouwen
+
+Je kan zowel voor macOS als Windows een standalone-versie maken met behulp van
+PyInstaller. Installeer eerst de afhankelijkheden voor runtime en build:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-build.txt
+```
+
+Bouw daarna de gewenste uitvoerbestanden. Op het doelplatform (macOS of
+Windows) voer je bijvoorbeeld uit:
+
+```bash
+python build_executable.py --target macos
+python build_executable.py --target windows
+```
+
+Standaard worden er twee varianten gemaakt:
+
+* `filehopper-<target>` — console-app met CLI-ondersteuning.
+* `filehopper-gui-<target>` — windowed app die rechtstreeks de GUI opent.
+
+De resultaten verschijnen in de map `dist/`.
+
+### Gebruikersgegevens
+
+Wanneer je een gebundelde versie gebruikt, worden de databestanden per gebruiker
+opgeslagen. Op Windows vind je ze in `%LOCALAPPDATA%\Filehopper`, op macOS in
+`~/Library/Application Support/Filehopper`. Hierdoor blijven gegevens behouden
+na updates.
+
 ## Voorbeelden
 
 ### Leverancier toevoegen

--- a/app_paths.py
+++ b/app_paths.py
@@ -1,0 +1,89 @@
+"""Helpers for resolving resource and data paths across packaging targets."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+APP_NAME = "Filehopper"
+
+
+def is_frozen() -> bool:
+    """Return ``True`` when running from a frozen/packaged executable."""
+
+    return bool(getattr(sys, "frozen", False))
+
+
+@lru_cache()
+def bundle_root() -> Path:
+    """Return the directory that contains bundled application resources."""
+
+    if is_frozen() and hasattr(sys, "_MEIPASS"):
+        return Path(sys._MEIPASS)  # type: ignore[attr-defined]
+    return Path(__file__).resolve().parent
+
+
+@lru_cache()
+def storage_dir() -> Path:
+    """Return the directory that should contain mutable application data."""
+
+    if is_frozen():
+        return _user_data_dir()
+    return Path.cwd()
+
+
+def _user_data_dir() -> Path:
+    home = Path.home()
+    if sys.platform.startswith("win"):
+        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
+        if base:
+            return Path(base) / APP_NAME
+        return home / "AppData" / "Local" / APP_NAME
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / APP_NAME
+    xdg_home = os.environ.get("XDG_DATA_HOME")
+    if xdg_home:
+        return Path(xdg_home) / APP_NAME
+    return home / ".local" / "share" / APP_NAME
+
+
+def data_file(name: str) -> str:
+    """Return a writable path for the data file ``name``.
+
+    When running from source the file remains relative so tests can redirect
+    storage by changing the current working directory. For frozen builds the
+    path resolves to the per-user storage directory.
+    """
+
+    if is_frozen():
+        path = storage_dir() / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return str(path)
+    return name
+
+
+def ensure_runtime_files(filenames: Iterable[str]) -> None:
+    """Ensure default data files exist in the runtime storage directory."""
+
+    if not is_frozen():
+        return
+
+    src_root = bundle_root()
+    dst_root = storage_dir()
+    dst_root.mkdir(parents=True, exist_ok=True)
+
+    for name in filenames:
+        dest = dst_root / name
+        if dest.exists():
+            continue
+        source = src_root / name
+        if source.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, dest)
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.touch()

--- a/build_executable.py
+++ b/build_executable.py
@@ -1,0 +1,135 @@
+"""Build standalone executables for Filehopper using PyInstaller."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+BUILD_DIR = PROJECT_ROOT / "build" / "pyinstaller"
+DIST_DIR = PROJECT_ROOT / "dist"
+SPEC_DIR = BUILD_DIR / "specs"
+
+DEFAULT_DATA_FILES = [
+    "clients_db.json",
+    "suppliers_db.json",
+    "delivery_addresses_db.json",
+    "app_settings.json",
+]
+
+
+class BuildError(RuntimeError):
+    """Raised when the PyInstaller invocation fails."""
+
+
+def _pyinstaller_cmd(entry: str, name: str, *, windowed: bool, data_files: Iterable[str]) -> List[str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        entry,
+        "--name",
+        name,
+        "--noconfirm",
+        "--clean",
+        "--distpath",
+        str(DIST_DIR),
+        "--workpath",
+        str(BUILD_DIR / "work"),
+        "--specpath",
+        str(SPEC_DIR),
+        "--collect-submodules",
+        "tksheet",
+    ]
+    cmd.append("--windowed" if windowed else "--console")
+
+    for filename in data_files:
+        src = PROJECT_ROOT / filename
+        if not src.exists():
+            continue
+        cmd.extend(["--add-data", f"{src}{os.pathsep}."])
+
+    return cmd
+
+
+def run_pyinstaller(entry: str, name: str, *, windowed: bool, data_files: Iterable[str]) -> None:
+    cmd = _pyinstaller_cmd(entry, name, windowed=windowed, data_files=data_files)
+    print("Running", " ".join(cmd))
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        raise BuildError(f"PyInstaller failed with exit code {result.returncode}")
+
+
+def build_targets(targets: Iterable[str], *, include_gui: bool, include_cli: bool, data_files: Iterable[str]) -> None:
+    data_files = list(data_files)
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    DIST_DIR.mkdir(parents=True, exist_ok=True)
+    SPEC_DIR.mkdir(parents=True, exist_ok=True)
+
+    for target in targets:
+        if include_cli:
+            run_pyinstaller("main.py", f"filehopper-{target}", windowed=False, data_files=data_files)
+        if include_gui:
+            run_pyinstaller("main.py", f"filehopper-gui-{target}", windowed=True, data_files=data_files)
+
+
+def _detect_target() -> str:
+    system = platform.system().lower()
+    if system.startswith("darwin"):
+        return "macos"
+    if system.startswith("windows"):
+        return "windows"
+    return system or "linux"
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        dest="targets",
+        action="append",
+        help="Operating system target label (default: current platform)",
+    )
+    parser.add_argument(
+        "--only-gui",
+        action="store_true",
+        help="Only build the windowed GUI executable",
+    )
+    parser.add_argument(
+        "--only-cli",
+        action="store_true",
+        help="Only build the console/CLI executable",
+    )
+    parser.add_argument(
+        "--data-file",
+        dest="data_files",
+        action="append",
+        help="Additional data file to bundle (relative to the project root)",
+    )
+
+    args = parser.parse_args(argv)
+
+    targets = args.targets or [_detect_target()]
+    data_files = DEFAULT_DATA_FILES + (args.data_files or [])
+
+    include_gui = not args.only_cli
+    include_cli = not args.only_gui
+
+    if not include_gui and not include_cli:
+        parser.error("At least one of GUI or CLI builds must be enabled")
+
+    try:
+        build_targets(targets, include_gui=include_gui, include_cli=include_cli, data_files=data_files)
+    except BuildError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/clients_db.py
+++ b/clients_db.py
@@ -4,8 +4,9 @@ from dataclasses import asdict
 from typing import List, Optional
 
 from models import Client
+from app_paths import data_file
 
-CLIENTS_DB_FILE = "clients_db.json"
+CLIENTS_DB_FILE = data_file("clients_db.json")
 
 
 class ClientsDB:

--- a/delivery_addresses_db.py
+++ b/delivery_addresses_db.py
@@ -5,8 +5,9 @@ from typing import List, Optional
 
 from models import DeliveryAddress
 from clients_db import ClientsDB, CLIENTS_DB_FILE
+from app_paths import data_file
 
-DELIVERY_DB_FILE = "delivery_addresses_db.json"
+DELIVERY_DB_FILE = data_file("delivery_addresses_db.json")
 
 
 class DeliveryAddressesDB:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sys
 from typing import List, Optional
 
+from app_paths import ensure_runtime_files
 from cli import (
     build_parser,
     cli_suppliers,
@@ -12,9 +13,17 @@ from cli import (
     cli_delivery_addresses,
 )
 
+RUNTIME_DATA_FILES = [
+    "clients_db.json",
+    "suppliers_db.json",
+    "delivery_addresses_db.json",
+    "app_settings.json",
+]
+
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Entry point for the Filehopper application."""
+    ensure_runtime_files(RUNTIME_DATA_FILES)
     argv = argv if argv is not None else sys.argv[1:]
     parser = build_parser()
     args = parser.parse_args(argv)

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,1 @@
+pyinstaller>=6.3

--- a/suppliers_db.py
+++ b/suppliers_db.py
@@ -4,8 +4,9 @@ from dataclasses import asdict
 from typing import List, Dict, Optional
 
 from models import Supplier
+from app_paths import data_file
 
-SUPPLIERS_DB_FILE = "suppliers_db.json"
+SUPPLIERS_DB_FILE = data_file("suppliers_db.json")
 
 
 class SuppliersDB:


### PR DESCRIPTION
## Summary
- add runtime path helpers so packaged binaries resolve and persist their JSON data
- add a PyInstaller build script plus build requirements for producing macOS/Windows executables
- document the new executable build workflow in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68db7cf090cc8323a34ec97d03d2e11e