### PR TITLE
Handle BOMs without description column

### DIFF
--- a/bom.py
+++ b/bom.py
@@ -86,7 +86,10 @@ def load_bom(path: str) -> pd.DataFrame:
         return low[lc]
 
     pn_c = need("PartNumber")
-    ds_c = need("Description")
+    try:
+        ds_c = need("Description")
+    except ValueError:
+        ds_c = None
     pr_c = need("Production")
 
     def find_any(names: List[str]) -> Optional[str]:
@@ -123,7 +126,12 @@ def load_bom(path: str) -> pd.DataFrame:
         mat_col = _find_col_by_regex(df, [r"\bmaterial", r"\bmateriaal", r"\bgrade\b"])
 
     df["PartNumber"] = df[pn_c].astype(str).str.strip()
-    df["Description"] = df[ds_c].astype(str).str.strip()
+    if ds_c is not None:
+        df["Description"] = df[ds_c].astype(str).fillna("").str.strip()
+    else:
+        # Fallback to PartNumber when no description column is present so that
+        # downstream code keeps working with a consistent schema.
+        df["Description"] = df["PartNumber"]
     df["Production"] = df[pr_c].astype(str).str.strip()
 
     if aantal_col is None:

--- a/tests/test_bom_optional_description.py
+++ b/tests/test_bom_optional_description.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+from bom import load_bom
+
+
+def test_load_bom_without_description(tmp_path):
+    bom_path = tmp_path / "bom.csv"
+    pd.DataFrame(
+        {
+            "PartNumber": ["PN1", "PN2"],
+            "Production": ["Laser", "Laser"],
+            "Aantal": [2, 1],
+        }
+    ).to_csv(bom_path, index=False)
+
+    df = load_bom(str(bom_path))
+
+    assert list(df.columns) == [
+        "PartNumber",
+        "Description",
+        "Production",
+        "Bestanden gevonden",
+        "Status",
+        "Materiaal",
+        "Aantal",
+        "Oppervlakte",
+        "Gewicht",
+    ]
+    assert df["Description"].tolist() == ["PN1", "PN2"]
+
+    grouped = df.groupby("PartNumber")["Aantal"].sum().to_dict()
+    assert grouped == {"PN1": 2, "PN2": 1}


### PR DESCRIPTION
## Summary
- allow loading BOM files that do not contain a Description column by falling back to the PartNumber values
- ensure the normalized BOM always includes a Description column for downstream code
- add a regression test that verifies BOM imports without Description still provide the expected schema

## Testing
- pytest tests/test_bom_optional_description.py

------
https://chatgpt.com/codex/tasks/task_b_68de4674c878832295a356b31c193da7