### PR TITLE
Fix missing defaultdict import for GUI copy per production

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import threading
 import unicodedata
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Optional


### PR DESCRIPTION
## Summary
- add the missing defaultdict import to gui.py so the copy-per-production workflow can build its finish mapping

## Testing
- python main.py *(fails: `_tkinter.TclError: no display name and no $DISPLAY environment variable`)*

------
https://chatgpt.com/codex/tasks/task_b_68de84e4ee348322875367e59e3b3113