### PR TITLE
Skip finish exports for blank finishes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -350,6 +350,9 @@ def cli_copy_per_prod(args):
     finish_meta_lookup: Dict[str, Dict[str, str]] = {}
     finish_lookup: Dict[str, str] = {}
     for _, row in df.iterrows():
+        finish_text = _to_str(row.get("Finish")).strip()
+        if not finish_text:
+            continue
         meta = describe_finish_combo(row.get("Finish"), row.get("RAL color"))
         key = meta["key"]
         if key in finish_meta_lookup:

--- a/gui.py
+++ b/gui.py
@@ -2752,6 +2752,9 @@ def start_gui():
             finish_meta_map: Dict[str, Dict[str, str]] = {}
             finish_part_numbers: Dict[str, set[str]] = defaultdict(set)
             for _, row in bom_df.iterrows():
+                finish_text = _to_str(row.get("Finish")).strip()
+                if not finish_text:
+                    continue
                 meta = describe_finish_combo(row.get("Finish"), row.get("RAL color"))
                 key = meta["key"]
                 if key not in finish_meta_map:

--- a/orders.py
+++ b/orders.py
@@ -815,19 +815,23 @@ def copy_per_production_and_orders(
         prod = (row.get("Production") or "").strip() or "_Onbekend"
         prod_to_rows[prod].append(row)
         pn = _to_str(row.get("PartNumber")).strip()
-        finish_meta = describe_finish_combo(row.get("Finish"), row.get("RAL color"))
-        finish_key = finish_meta["key"]
-        group = finish_groups.get(finish_key)
-        if group is None:
-            group = {
-                **finish_meta,
-                "rows": [],
-                "part_numbers": set(),
-            }
-            finish_groups[finish_key] = group
-        group["rows"].append(row)
-        if pn:
-            group["part_numbers"].add(pn)
+        finish_text = _to_str(row.get("Finish")).strip()
+        if finish_text:
+            finish_meta = describe_finish_combo(
+                row.get("Finish"), row.get("RAL color")
+            )
+            finish_key = finish_meta["key"]
+            group = finish_groups.get(finish_key)
+            if group is None:
+                group = {
+                    **finish_meta,
+                    "rows": [],
+                    "part_numbers": set(),
+                }
+                finish_groups[finish_key] = group
+            group["rows"].append(row)
+            if pn:
+                group["part_numbers"].add(pn)
 
     today_date = datetime.date.today()
     today = today_date.strftime("%Y-%m-%d")

--- a/tests/test_finish_export.py
+++ b/tests/test_finish_export.py
@@ -1,4 +1,5 @@
 import datetime
+import zipfile
 
 import pandas as pd
 import pytest
@@ -183,7 +184,7 @@ def test_finish_exports_written(tmp_path, zip_parts):
     finish_dir_2 = dest / finish_dir_2_name
     finish_dir_3_name = "Finish-" + _normalize_finish_folder("Geanodiseerd")
     finish_dir_3 = dest / finish_dir_3_name
-    finish_dir_4_name = (
+    missing_finish_dir_name = (
         "Finish-"
         + _normalize_finish_folder(" ")
         + "-"
@@ -200,8 +201,18 @@ def test_finish_exports_written(tmp_path, zip_parts):
         p.name for p in dest.iterdir() if p.is_dir() and p.name.startswith("Finish-")
     )
     assert finish_dirs == sorted(
-        [finish_dir_1_name, finish_dir_2_name, finish_dir_3_name, finish_dir_4_name]
+        [finish_dir_1_name, finish_dir_2_name, finish_dir_3_name]
     )
+    assert not (dest / missing_finish_dir_name).exists()
+
+    prod_dir = dest / "Laser"
+    if zip_parts:
+        archive = prod_dir / "Laser.zip"
+        assert archive.is_file()
+        with zipfile.ZipFile(archive) as zf:
+            assert any(name.endswith("PN3.pdf") for name in zf.namelist())
+    else:
+        assert (prod_dir / "PN3.pdf").is_file()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- ignore BOM rows without a finish when building finish export groups so blank values do not create Finish-_Onbekend folders
- apply the same blank-finish filter to CLI and GUI finish metadata so overrides only target real finish combinations
- update finish export tests to assert that blank finishes remain ungrouped and adjust expectations accordingly

## Testing
- pytest tests/test_finish_export.py

------
https://chatgpt.com/codex/tasks/task_b_68de8edd6f8c83228bcd9c90b90cfc94