### PR TITLE
Add Standaard bon option to supplier document selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ python cli.py clients export-csv clients_export.csv
 
 ### Documentnummer prefixen
 
-Bestelbonnen gebruiken doorgaans een nummer dat begint met `BB-`, terwijl
-offerteaanvragen `OFF-` gebruiken. De helperfunctie
+Bestelbonnen gebruiken doorgaans een nummer dat begint met `BB-`,
+standaard bonnen met `SB-` en offerteaanvragen met `OFF-`. De helperfunctie
 `_prefix_for_doc_type("Bestelbon")` geeft bijvoorbeeld `BB-` terug zodat deze
 prefix automatisch kan worden ingevuld.
 

--- a/gui.py
+++ b/gui.py
@@ -1022,7 +1022,12 @@ def start_gui():
                 for a in self.delivery_db.addresses_sorted()
             ]
 
-            doc_type_opts = ["Geen", "Bestelbon", "Offerteaanvraag"]
+            doc_type_opts = [
+                "Geen",
+                "Bestelbon",
+                "Standaard bon",
+                "Offerteaanvraag",
+            ]
             self._doc_type_prefixes = {
                 _prefix_for_doc_type(t) for t in doc_type_opts
             }
@@ -1271,8 +1276,8 @@ def start_gui():
                 if not doc_var:
                     continue
                 val = combo.get().strip().lower()
-                if val in ("(geen)", "geen"):
-                    doc_var.set("Geen")
+                if val in ("", "(geen)", "geen"):
+                    doc_var.set("Standaard bon")
                 else:
                     doc_var.set("Bestelbon")
                 self._on_doc_type_change(sel_key)

--- a/orders.py
+++ b/orders.py
@@ -126,6 +126,8 @@ def _prefix_for_doc_type(doc_type: str) -> str:
     Unknown types return an empty prefix.
     """
     t = (doc_type or "").strip().lower()
+    if t.startswith("standaard"):
+        return "SB-"
     if t.startswith("bestel"):
         return "BB-"
     if t.startswith("offerte"):

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -65,6 +65,7 @@ def test_doc_number_in_name_and_header(tmp_path):
 
 
 def test_prefix_helper():
+    assert _prefix_for_doc_type("Standaard bon") == "SB-"
     assert _prefix_for_doc_type("Bestelbon") == "BB-"
     assert _prefix_for_doc_type("Offerteaanvraag") == "OFF-"
     assert _prefix_for_doc_type("Onbekend") == ""

--- a/tests/test_doc_type_none_selection.py
+++ b/tests/test_doc_type_none_selection.py
@@ -11,6 +11,8 @@ from delivery_addresses_db import DeliveryAddressesDB
 # ``pandas``.  Re-implement the small helper here to keep tests lightweight.
 def _prefix_for_doc_type(doc_type: str) -> str:
     t = (doc_type or "").strip().lower()
+    if t.startswith("standaard"):
+        return "SB-"
     if t.startswith("bestel"):
         return "BB-"
     if t.startswith("offerte"):
@@ -89,7 +91,7 @@ def _load_supplier_frame():
 SupplierSelectionFrame = _load_supplier_frame()
 
 
-def test_supplier_geen_sets_doc_type_to_geen():
+def test_supplier_geen_sets_doc_type_to_standaard():
     class DummySel:
         _on_combo_change = SupplierSelectionFrame._on_combo_change
         _on_doc_type_change = SupplierSelectionFrame._on_doc_type_change
@@ -102,14 +104,14 @@ def test_supplier_geen_sets_doc_type_to_geen():
 
     sel = DummySel()
     sel._on_combo_change()
-    assert sel.doc_vars["Prod"].get() == "Geen"
+    assert sel.doc_vars["Prod"].get() == "Standaard bon"
 
     sel.rows[0][1].set("Other")
     sel._on_combo_change()
     assert sel.doc_vars["Prod"].get() == "Bestelbon"
 
 
-def test_confirm_persists_geen_doc_type():
+def test_confirm_persists_standaard_doc_type():
     class DummySel:
         _on_combo_change = SupplierSelectionFrame._on_combo_change
         _on_doc_type_change = SupplierSelectionFrame._on_doc_type_change
@@ -151,5 +153,5 @@ def test_confirm_persists_geen_doc_type():
     sel._confirm()
     assert sel.callback_args is not None
     _, doc_map, *_ = sel.callback_args
-    assert doc_map["Prod"] == "Geen"
+    assert doc_map["Prod"] == "Standaard bon"
 


### PR DESCRIPTION
## Summary
- add the "Standaard bon" document type to supplier selection defaults and refresh prefix tracking
- map the new document type to the SB- prefix in the shared helper and documentation
- extend tests to cover the new default behaviour and prefix mapping

## Testing
- pytest tests/test_doc_type_none_selection.py tests/test_doc_numbers.py

------
https://chatgpt.com/codex/tasks/task_b_68dfb914d5dc83228dfb4d3743c3cf36