### PR TITLE
Add Standaard bon option to supplier doc type selection

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1032,7 +1032,12 @@ def start_gui():
                 for a in self.delivery_db.addresses_sorted()
             ]
 
-            doc_type_opts = ["Geen", "Bestelbon", "Offerteaanvraag"]
+            doc_type_opts = [
+                "Geen",
+                "Bestelbon",
+                "Standaard bon",
+                "Offerteaanvraag",
+            ]
             self._doc_type_prefixes = {
                 _prefix_for_doc_type(t) for t in doc_type_opts
             }

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -66,6 +66,7 @@ def test_doc_number_in_name_and_header(tmp_path):
 
 def test_prefix_helper():
     assert _prefix_for_doc_type("Bestelbon") == "BB-"
+    assert _prefix_for_doc_type("Standaard bon") == "BB-"
     assert _prefix_for_doc_type("Offerteaanvraag") == "OFF-"
     assert _prefix_for_doc_type("Onbekend") == ""
 

--- a/tests/test_doc_type_none_selection.py
+++ b/tests/test_doc_type_none_selection.py
@@ -11,6 +11,8 @@ from delivery_addresses_db import DeliveryAddressesDB
 # ``pandas``.  Re-implement the small helper here to keep tests lightweight.
 def _prefix_for_doc_type(doc_type: str) -> str:
     t = (doc_type or "").strip().lower()
+    if t.startswith("standaard"):
+        return "BB-"
     if t.startswith("bestel"):
         return "BB-"
     if t.startswith("offerte"):


### PR DESCRIPTION
## Summary
- add the "Standaard bon" option to the supplier document type combobox
- ensure the document type prefix helper covers the new option and expand tests accordingly

## Testing
- pytest tests/test_doc_numbers.py tests/test_doc_type_none_selection.py

------
https://chatgpt.com/codex/tasks/task_b_68dfbd74097883228b3cb0be11ff17f9