### PR TITLE
Adjust standard doc prefix for Standaard documents

### DIFF
--- a/orders.py
+++ b/orders.py
@@ -127,7 +127,7 @@ def _prefix_for_doc_type(doc_type: str) -> str:
     """
     t = (doc_type or "").strip().lower()
     if t.startswith("standaard"):
-        return "BB-"
+        return "BOM-"
     if t.startswith("bestel"):
         return "BB-"
     if t.startswith("offerte"):

--- a/tests/test_doc_numbers.py
+++ b/tests/test_doc_numbers.py
@@ -66,7 +66,7 @@ def test_doc_number_in_name_and_header(tmp_path):
 
 def test_prefix_helper():
     assert _prefix_for_doc_type("Bestelbon") == "BB-"
-    assert _prefix_for_doc_type("Standaard bon") == "BB-"
+    assert _prefix_for_doc_type("Standaard bon") == "BOM-"
     assert _prefix_for_doc_type("Offerteaanvraag") == "OFF-"
     assert _prefix_for_doc_type("Onbekend") == ""
 


### PR DESCRIPTION
## Summary
- update the standard document type prefix so Standaard* variants use BOM-
- align the document number prefix test to expect the new BOM- prefix

## Testing
- pytest tests/test_doc_numbers.py

------
https://chatgpt.com/codex/tasks/task_b_68dfc17ae320832292ccd87246c763db