### PR TITLE
Set standard document type when supplier selection is empty

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1210,7 +1210,7 @@ def start_gui():
                 combo.set("(geen)")
 
             for sel_key in self.doc_vars:
-                self.doc_vars[sel_key].set("Geen")
+                self.doc_vars[sel_key].set("Standaard bon")
 
             for dcombo in self.delivery_combos.values():
                 dcombo.set("Geen")
@@ -1288,9 +1288,10 @@ def start_gui():
                 doc_var = self.doc_vars.get(sel_key)
                 if not doc_var:
                     continue
-                val = combo.get().strip().lower()
-                if val in ("(geen)", "geen"):
-                    doc_var.set("Geen")
+                raw_val = combo.get().strip()
+                norm_val = raw_val.lower()
+                if not raw_val or norm_val in ("(geen)", "geen"):
+                    doc_var.set("Standaard bon")
                 else:
                     doc_var.set("Bestelbon")
                 self._on_doc_type_change(sel_key)


### PR DESCRIPTION
## Summary
- update the supplier selection combo handling so that empty or “(geen)” values default to the "Standaard bon" document type
- ensure clearing saved suppliers applies the same default and expand the focused tests to cover these scenarios

## Testing
- pytest tests/test_doc_type_none_selection.py

------
https://chatgpt.com/codex/tasks/task_b_68dfc19098088322815bc59187b0e8bc