### PR TITLE
Add supplier metadata columns to BOM handling

### DIFF
--- a/bom.py
+++ b/bom.py
@@ -163,6 +163,16 @@ def load_bom(path: str) -> pd.DataFrame:
 
     df["Materiaal"] = _text_column(mat_col)
 
+    supplier_col = find_any(["Supplier"])
+    supplier_code_col = find_any(["Supplier code"])
+    manufacturer_col = find_any(["Manufacturer"])
+    manufacturer_code_col = find_any(["Manufacturer code"])
+
+    df["Supplier"] = _text_column(supplier_col)
+    df["Supplier code"] = _text_column(supplier_code_col)
+    df["Manufacturer"] = _text_column(manufacturer_col)
+    df["Manufacturer code"] = _text_column(manufacturer_code_col)
+
     finish_col = find_any(["Finish"])
     if finish_col is None:
         finish_col = _find_col_by_regex(df, [r"\bfinish\b"])
@@ -186,6 +196,10 @@ def load_bom(path: str) -> pd.DataFrame:
             "Bestanden gevonden",
             "Status",
             "Materiaal",
+            "Supplier",
+            "Supplier code",
+            "Manufacturer",
+            "Manufacturer code",
             "Finish",
             "RAL color",
             "Aantal",

--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -34,8 +34,8 @@ wordt door ``Ctrl+Z`` in omgekeerde volgorde verwerkt.
 
 CSV-schema
 ==========
-Er worden twaalf vaste kolommen geëxporteerd in deze volgorde:
-``PartNumber, Description, QTY., Profile, Length profile, Thickness, Production, Material, Finish, RAL color, Weight (kg), Surface Area (m²)``.
+Er worden zestien vaste kolommen geëxporteerd in deze volgorde:
+``PartNumber, Description, QTY., Profile, Length profile, Thickness, Production, Material, Supplier, Supplier code, Manufacturer, Manufacturer code, Finish, RAL color, Weight (kg), Surface Area (m²)``.
 Velden worden met een komma gescheiden en automatisch gequote door ``csv.writer``.
 
 Notebook-integratie
@@ -122,6 +122,10 @@ class BOMCustomTab(ttk.Frame):
         "Thickness",
         "Production",
         "Material",
+        "Supplier",
+        "Supplier code",
+        "Manufacturer",
+        "Manufacturer code",
         "Finish",
         "RAL color",
         "Weight (kg)",

--- a/tests/test_bom_optional_description.py
+++ b/tests/test_bom_optional_description.py
@@ -22,11 +22,21 @@ def test_load_bom_without_description(tmp_path):
         "Bestanden gevonden",
         "Status",
         "Materiaal",
+        "Supplier",
+        "Supplier code",
+        "Manufacturer",
+        "Manufacturer code",
+        "Finish",
+        "RAL color",
         "Aantal",
         "Oppervlakte",
         "Gewicht",
     ]
     assert df["Description"].tolist() == ["PN1", "PN2"]
+    assert df["Supplier"].tolist() == ["", ""]
+    assert df["Supplier code"].tolist() == ["", ""]
+    assert df["Manufacturer"].tolist() == ["", ""]
+    assert df["Manufacturer code"].tolist() == ["", ""]
 
     grouped = df.groupby("PartNumber")["Aantal"].sum().to_dict()
     assert grouped == {"PN1": 2, "PN2": 1}

--- a/tests/test_bom_supplier_fields.py
+++ b/tests/test_bom_supplier_fields.py
@@ -1,0 +1,86 @@
+import csv
+
+import csv
+
+import pandas as pd
+
+from bom import load_bom
+from bom_custom_tab import BOMCustomTab
+
+
+EXPECTED_COLUMNS = [
+    "PartNumber",
+    "Description",
+    "Production",
+    "Bestanden gevonden",
+    "Status",
+    "Materiaal",
+    "Supplier",
+    "Supplier code",
+    "Manufacturer",
+    "Manufacturer code",
+    "Finish",
+    "RAL color",
+    "Aantal",
+    "Oppervlakte",
+    "Gewicht",
+]
+
+
+def test_load_bom_preserves_supplier_fields(tmp_path):
+    bom_path = tmp_path / "bom.csv"
+    pd.DataFrame(
+        {
+            "PartNumber": ["PN1"],
+            "Description": ["Widget"],
+            "Production": ["Laser"],
+            "Supplier": ["  Supplier NV  "],
+            "Supplier code": [" SUP-001 "],
+            "Manufacturer": [" Maker BV "],
+            "Manufacturer code": [" M-42 "],
+            "Aantal": [3],
+        }
+    ).to_csv(bom_path, index=False)
+
+    df = load_bom(str(bom_path))
+
+    assert list(df.columns) == EXPECTED_COLUMNS
+    assert df.loc[0, "Supplier"] == "Supplier NV"
+    assert df.loc[0, "Supplier code"] == "SUP-001"
+    assert df.loc[0, "Manufacturer"] == "Maker BV"
+    assert df.loc[0, "Manufacturer code"] == "M-42"
+
+
+def test_custom_bom_export_includes_supplier_columns(tmp_path):
+    tab = object.__new__(BOMCustomTab)
+    export_path = tmp_path / "custom.csv"
+    rows = [
+        [
+            "PN1",
+            "Panel",
+            "5",
+            "L",
+            "2500",
+            "5",
+            "Laser",
+            "Steel",
+            " Supplier BV ",
+            " SUP-42 ",
+            " Maker BV ",
+            " M-007 ",
+            "Anodized",
+            "RAL9005",
+            "12",
+            "3.4",
+        ]
+    ]
+
+    BOMCustomTab._write_csv(tab, export_path, rows)
+
+    with export_path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        header = next(reader)
+        data = next(reader)
+
+    assert header == list(BOMCustomTab.HEADERS)
+    assert data[8:12] == ["Supplier BV", "SUP-42", "Maker BV", "M-007"]


### PR DESCRIPTION
## Summary
- expand the custom BOM schema with supplier and manufacturer metadata columns
- update BOM loading to normalise the optional supplier and manufacturer fields
- add regression tests ensuring BOM parsing and custom exports keep the new columns

## Testing
- pytest tests/test_bom_optional_description.py tests/test_bom_supplier_fields.py

------
https://chatgpt.com/codex/tasks/task_b_68dff80798fc832291ed2c4b8782fa86