### PR TITLE
Add shared BOM template download actions

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -62,7 +62,9 @@ from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import tkinter as tk
 import tkinter.font as tkfont
-from tkinter import messagebox, ttk
+from tkinter import filedialog, messagebox, ttk
+
+import pandas as pd
 
 try:
     import tksheet
@@ -172,6 +174,9 @@ class BOMCustomTab(ttk.Frame):
         export_btn = ttk.Button(bar, text="Exporteren", command=self._export_temp)
         export_btn.pack(side="left", padx=(0, 6))
 
+        template_btn = ttk.Button(bar, text="Download template", command=self._download_template)
+        template_btn.pack(side="left", padx=(0, 6))
+
         ttk.Label(bar, textvariable=self.status_var, anchor="w").pack(side="left", fill="x", expand=True)
 
     def _build_sheet(self) -> None:
@@ -222,6 +227,36 @@ class BOMCustomTab(ttk.Frame):
     # Helpers
     def _update_status(self, text: str) -> None:
         self.status_var.set(text)
+
+    # ------------------------------------------------------------------
+    # Template
+    def _download_template(self) -> None:
+        """Vraag een doelpad en schrijf een leeg Excel-sjabloon."""
+
+        path_str = filedialog.asksaveasfilename(
+            parent=self,
+            title="BOM-template opslaan",
+            defaultextension=".xlsx",
+            filetypes=(("Excel-werkboek", "*.xlsx"), ("Alle bestanden", "*.*")),
+        )
+        if not path_str:
+            self._update_status("Download geannuleerd.")
+            return
+
+        target_path = Path(path_str)
+        try:
+            self.write_template_workbook(target_path)
+        except Exception as exc:
+            messagebox.showerror("Opslaan mislukt", str(exc), parent=self)
+            self._update_status("Fout bij opslaan van template.")
+            return
+
+        messagebox.showinfo(
+            "Template opgeslagen",
+            f"Leeg BOM-sjabloon opgeslagen als:\n{target_path}",
+            parent=self,
+        )
+        self._update_status(f"Template opgeslagen naar {target_path}.")
 
     def _snapshot_data(self) -> List[List[str]]:
         data = self.sheet.get_sheet_data()
@@ -658,6 +693,16 @@ class BOMCustomTab(ttk.Frame):
                 while len(cells) < len(self.HEADERS):
                     cells.append("")
                 writer.writerow(cells[: len(self.HEADERS)])
+
+    @classmethod
+    def write_template_workbook(cls, target: Path) -> None:
+        """Schrijf een leeg Excel-sjabloon met de standaardkolommen."""
+
+        normalized = Path(target)
+        if not normalized.parent.exists():
+            normalized.parent.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame(columns=cls.HEADERS)
+        df.to_excel(normalized, index=False)
 
     # ------------------------------------------------------------------
     # API

--- a/gui.py
+++ b/gui.py
@@ -1555,6 +1555,36 @@ def start_gui():
                 self.app.bundle_dry_run_var,
             )
 
+            template_frame = tk.LabelFrame(
+                export_options,
+                text="BOM-template",
+            )
+            template_frame.grid(
+                row=export_options.grid_size()[1],
+                column=0,
+                sticky="ew",
+                padx=12,
+                pady=(10, 12),
+            )
+            template_frame.columnconfigure(0, weight=1)
+
+            tk.Label(
+                template_frame,
+                text=(
+                    "Download een leeg Excel-sjabloon met alle kolommen van de BOM."
+                    " Handig om gegevens vooraf in te vullen of te delen met collega's."
+                ),
+                justify="left",
+                anchor="w",
+                wraplength=480,
+            ).grid(row=0, column=0, sticky="ew", padx=10, pady=(8, 4))
+
+            tk.Button(
+                template_frame,
+                text="Download BOM template",
+                command=self._download_bom_template,
+            ).grid(row=1, column=0, sticky="w", padx=10, pady=(0, 10))
+
             footer_frame = tk.LabelFrame(
                 self,
                 text="Bestelbon/offerte onderschrift",
@@ -1699,6 +1729,33 @@ def start_gui():
         def _reset_footer_note(self) -> None:
             self.app.update_footer_note(DEFAULT_FOOTER_NOTE)
             self._reload_footer_note()
+
+        def _download_bom_template(self) -> None:
+            path_str = filedialog.asksaveasfilename(
+                parent=self,
+                title="BOM-template opslaan",
+                defaultextension=".xlsx",
+                filetypes=(("Excel-werkboek", "*.xlsx"), ("Alle bestanden", "*.*")),
+            )
+            if not path_str:
+                return
+
+            target_path = Path(path_str)
+            try:
+                BOMCustomTab.write_template_workbook(target_path)
+            except Exception as exc:
+                messagebox.showerror("Opslaan mislukt", str(exc), parent=self)
+                return
+
+            messagebox.showinfo(
+                "Template opgeslagen",
+                (
+                    "Het lege BOM-sjabloon is opgeslagen. Vul het formulier in en"
+                    " importeer de gegevens later in de Custom BOM-tab.\n\n"
+                    f"Locatie: {target_path}"
+                ),
+                parent=self,
+            )
 
         def _update_listbox_height(self, item_count: int) -> None:
             visible = max(1, item_count)


### PR DESCRIPTION
## Summary
- add a shared helper in `BOMCustomTab` to generate an empty BOM Excel template
- provide a download button in the custom BOM toolbar that saves the template and reports status
- add a settings panel section with guidance and a download button for the BOM template

## Testing
- not run (GUI-focused changes)


------
https://chatgpt.com/codex/tasks/task_b_68dff81975608322a8c93cb36f9f8c4b