### PR TITLE
Expose supplier columns in custom BOM tab

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -35,7 +35,7 @@ wordt door ``Ctrl+Z`` in omgekeerde volgorde verwerkt.
 CSV-schema
 ==========
 Er worden zestien vaste kolommen geëxporteerd in deze volgorde:
-``PartNumber, Description, QTY., Profile, Length profile, Thickness, Production, Material, Supplier, Supplier code, Manufacturer, Manufacturer code, Finish, RAL color, Weight (kg), Surface Area (m²)``.
+``PartNumber, Description, QTY., Profile, Length profile, Thickness, Production, Material, Finish, RAL color, Weight (kg), Surface Area (m²), Supplier, Supplier code, Manufacturer, Manufacturer code``.
 Velden worden met een komma gescheiden en automatisch gequote door ``csv.writer``.
 
 Notebook-integratie
@@ -124,14 +124,14 @@ class BOMCustomTab(ttk.Frame):
         "Thickness",
         "Production",
         "Material",
-        "Supplier",
-        "Supplier code",
-        "Manufacturer",
-        "Manufacturer code",
         "Finish",
         "RAL color",
         "Weight (kg)",
         "Surface Area (m²)",
+        "Supplier",
+        "Supplier code",
+        "Manufacturer",
+        "Manufacturer code",
     )
     DEFAULT_EMPTY_ROWS: int = 20
     COLUMN_PADDING: int = 24

--- a/tests/test_bom_supplier_fields.py
+++ b/tests/test_bom_supplier_fields.py
@@ -64,14 +64,14 @@ def test_custom_bom_export_includes_supplier_columns(tmp_path):
             "5",
             "Laser",
             "Steel",
-            " Supplier BV ",
-            " SUP-42 ",
-            " Maker BV ",
-            " M-007 ",
             "Anodized",
             "RAL9005",
             "12",
             "3.4",
+            " Supplier BV ",
+            " SUP-42 ",
+            " Maker BV ",
+            " M-007 ",
         ]
     ]
 
@@ -82,5 +82,11 @@ def test_custom_bom_export_includes_supplier_columns(tmp_path):
         header = next(reader)
         data = next(reader)
 
+    assert list(BOMCustomTab.HEADERS[-4:]) == [
+        "Supplier",
+        "Supplier code",
+        "Manufacturer",
+        "Manufacturer code",
+    ]
     assert header == list(BOMCustomTab.HEADERS)
-    assert data[8:12] == ["Supplier BV", "SUP-42", "Maker BV", "M-007"]
+    assert data[-4:] == ["Supplier BV", "SUP-42", "Maker BV", "M-007"]


### PR DESCRIPTION
## Summary
- append the supplier and manufacturer columns to the custom BOM tab header configuration so they appear in the grid and exports
- update documentation and tests to reflect the extended header ordering and verify the CSV output includes the new columns

## Testing
- pytest tests/test_bom_supplier_fields.py tests/test_bom_optional_description.py

------
https://chatgpt.com/codex/tasks/task_b_68dffc5c102483228a0e4681ac5a9b45