### PR TITLE
Set default filename for BOM template downloads

### DIFF
--- a/bom_custom_tab.py
+++ b/bom_custom_tab.py
@@ -133,6 +133,7 @@ class BOMCustomTab(ttk.Frame):
         "Manufacturer",
         "Manufacturer code",
     )
+    TEMPLATE_DEFAULT_FILENAME: str = "BOM-FileHopper-Temp.xlsx"
     DEFAULT_EMPTY_ROWS: int = 20
     COLUMN_PADDING: int = 24
     TRAILING_GUTTER: int = 12
@@ -242,6 +243,7 @@ class BOMCustomTab(ttk.Frame):
             title="BOM-template opslaan",
             defaultextension=".xlsx",
             filetypes=(("Excel-werkboek", "*.xlsx"), ("Alle bestanden", "*.*")),
+            initialfile=self.default_template_filename(),
         )
         if not path_str:
             self._update_status("Download geannuleerd.")
@@ -707,6 +709,12 @@ class BOMCustomTab(ttk.Frame):
             normalized.parent.mkdir(parents=True, exist_ok=True)
         df = pd.DataFrame(columns=cls.HEADERS)
         df.to_excel(normalized, index=False)
+
+    @classmethod
+    def default_template_filename(cls) -> str:
+        """Geef de standaard bestandsnaam voor het templatesjabloon terug."""
+
+        return cls.TEMPLATE_DEFAULT_FILENAME
 
     # ------------------------------------------------------------------
     # API

--- a/gui.py
+++ b/gui.py
@@ -1736,6 +1736,7 @@ def start_gui():
                 title="BOM-template opslaan",
                 defaultextension=".xlsx",
                 filetypes=(("Excel-werkboek", "*.xlsx"), ("Alle bestanden", "*.*")),
+                initialfile=BOMCustomTab.default_template_filename(),
             )
             if not path_str:
                 return


### PR DESCRIPTION
## Summary
- add a reusable default filename helper for BOM template exports
- ensure both template download dialogs pre-populate with BOM-FileHopper-Temp.xlsx

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e2810df6d48322adcd095baa2c8ab1