### PR TITLE
Remove redundant zip checkbuttons from advanced options

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -2252,28 +2252,16 @@ def start_gui():
             self._rebuild_extension_checkbuttons()
             tk.Checkbutton(
                 options_frame,
-                text="Zip per productie",
-                variable=self.zip_var,
+                text="Zip per productie/finish",
+                variable=self.zip_per_finish_var,
                 anchor="w",
+                command=self._toggle_zip_per_finish,
             ).pack(anchor="w", pady=2)
             tk.Checkbutton(
                 options_frame,
                 text="Finish export",
                 variable=self.finish_export_var,
                 anchor="w",
-            ).pack(anchor="w", pady=2)
-            tk.Checkbutton(
-                options_frame,
-                text="Zip finish export",
-                variable=self.zip_finish_var,
-                anchor="w",
-            ).pack(anchor="w", pady=2)
-            tk.Checkbutton(
-                options_frame,
-                text="Zip per productie/finish",
-                variable=self.zip_per_finish_var,
-                anchor="w",
-                command=self._toggle_zip_per_finish,
             ).pack(anchor="w", pady=2)
             tk.Checkbutton(
                 export_name_inner,


### PR DESCRIPTION
## Summary
- remove the dedicated "Zip per productie" and "Zip finish export" checkbuttons from the advanced options frame
- show the combined "Zip per productie/finish" checkbutton ahead of the remaining "Finish export" option so it is the first visible choice

## Testing
- python - <<'PY'
import tkinter as tk
from types import SimpleNamespace

interp = tk.Tcl()
self = SimpleNamespace()
self.zip_var = tk.IntVar(master=interp, value=0)
self.zip_finish_var = tk.IntVar(master=interp, value=0)
self.zip_per_finish_var = tk.IntVar(master=interp, value=0)

def _update_zip_per_finish_var(self, *_args):
    desired = 1 if (self.zip_var.get() and self.zip_finish_var.get()) else 0
    if self.zip_per_finish_var.get() != desired:
        self.zip_per_finish_var.set(desired)

def _toggle_zip_per_finish(self):
    enabled = bool(self.zip_per_finish_var.get())
    desired = 1 if enabled else 0
    if self.zip_var.get() != desired:
        self.zip_var.set(desired)
    if self.zip_finish_var.get() != desired:
        self.zip_finish_var.set(desired)

self.zip_var.trace_add("write", lambda *_: _update_zip_per_finish_var(self))
self.zip_finish_var.trace_add("write", lambda *_: _update_zip_per_finish_var(self))

_update_zip_per_finish_var(self)
print("initial:", self.zip_var.get(), self.zip_finish_var.get(), self.zip_per_finish_var.get())

self.zip_per_finish_var.set(1)
_toggle_zip_per_finish(self)
print("after toggle on:", self.zip_var.get(), self.zip_finish_var.get(), self.zip_per_finish_var.get())

self.zip_var.set(0)
print("after direct zip off:", self.zip_var.get(), self.zip_finish_var.get(), self.zip_per_finish_var.get())

self.zip_var.set(1)
self.zip_finish_var.set(1)
print("after both on:", self.zip_var.get(), self.zip_finish_var.get(), self.zip_per_finish_var.get())

self.zip_per_finish_var.set(0)
_toggle_zip_per_finish(self)
print("after toggle off:", self.zip_var.get(), self.zip_finish_var.get(), self.zip_per_finish_var.get())
PY

------
https://chatgpt.com/codex/tasks/task_b_68e28827c4f883229b5f30dd553dfb0c