### PR TITLE
Fix supplier favorite filter fallback

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1367,6 +1367,19 @@ def start_gui():
             combo.set(value)
             setattr(combo, "_supplier_focus_seen", False)
 
+        @staticmethod
+        def _strip_favorite_marker(text: str) -> str:
+            """Remove the display favorite marker without depending on module globals."""
+
+            try:
+                return strip_favorite_marker(text)
+            except NameError:
+                value = "" if text is None else str(text)
+                for marker in ("★ ", "* "):
+                    if marker and marker in value:
+                        return value.replace(marker, "", 1)
+                return value
+
         def set_opticutter_notice(self, message: str) -> None:
             text = (message or "").strip()
             if text:
@@ -2378,7 +2391,9 @@ def start_gui():
 
             def _option_norm(opt: str) -> str:
                 name = disp_to_name.get(opt, opt)
-                cleaned = strip_favorite_marker(name if name else opt)
+                cleaned = SupplierSelectionFrame._strip_favorite_marker(
+                    name if name else opt
+                )
                 cleaned = cleaned.replace("(", "").replace(")", "")
                 return _norm(cleaned)
 
@@ -6788,4 +6803,3 @@ def start_gui():
                 )
 
     App().mainloop()
-


### PR DESCRIPTION
### Motivation
- Tests failed when the `SupplierSelectionFrame` was extracted for unit tests because the module-level helper `strip_favorite_marker` was not available, causing a `NameError` during combo filtering. 
- The supplier name normalization used by type-to-filter must ignore the display favorite marker so accent-insensitive matching and favorite ordering work in both normal and extracted contexts.

### Description
- Added a `@staticmethod` `SupplierSelectionFrame._strip_favorite_marker(text: str)` that first tries to call the module-level `strip_favorite_marker` and falls back to an internal implementation that safely converts the value to string and strips `"★ "` or `"* "` prefixes. 
- Replaced direct calls to `strip_favorite_marker(...)` in the combo filtering logic with `SupplierSelectionFrame._strip_favorite_marker(...)` so the helper works when module globals are not present. 
- Small defensive change ensures the fallback uses `"" if text is None else str(text)` to avoid relying on other module helpers.

### Testing
- Ran `pytest tests/test_accent_filter.py -q` which completed with `4 passed` and no failures. 
- Ran the full suite with `pytest -q` which completed with `124 passed, 13 skipped` and one deprecation warning. 
- All tests relevant to supplier filtering now pass and the change was committed on the current branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a0c06b9bc8322bbd4032abf0181ed)